### PR TITLE
Add OLIDS framework documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A dbt project for migrating key data models from HealtheIntent (Vertica) to Snowflake.
 
+## One London Integrated Data Set (OLIDS)
+
+This project aligns with the [One London Integrated Data Set (OLIDS)](https://github.com/NHSISL/Datasets) framework - a canonical data model that transforms multiple healthcare datasets into a standardized format. OLIDS enables data interrogation across London's Integrated Care Systems without being constrained by original source system structures.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary
- Added brief section explaining OLIDS (One London Integrated Data Set) framework
- Included link to NHS repository for further reference
- Provides context on how this project aligns with standardized healthcare data modeling

## Test plan
- [x] Documentation compiles correctly
- [x] Link to NHS repository is accessible
- [x] Section fits well with existing README structure