### PR TITLE
fix: update workflows to use GitHub Projects Status fields instead of labels

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,8 +22,8 @@ This directory contains automated workflows that help manage the repository.
 - Fetches labels from referenced issues
 - Applies those labels to the PR (without duplicating existing labels)
 - Assigns referenced issues to the PR author
-- Adds "Code Review" label to referenced issues
-- Handles multiple issue references
+- Updates issue **Status** to "Code Review" in GitHub Projects
+- Handles multiple issue references and multiple projects
 - Continues working even if some issues can't be fetched
 
 ### auto-move-assigned-issues.yml
@@ -32,9 +32,9 @@ This directory contains automated workflows that help manage the repository.
 
 **How it works:**
 - Triggers when an issue is assigned to someone
-- Removes existing status labels (In Progress, Code Review, Done)
-- Adds "In Progress" label to the assigned issue
-- Provides task board automation
+- Updates issue **Status** to "In Progress" in GitHub Projects
+- Works across multiple projects if issue is in several
+- Provides automated task board management
 
 **Supported issue reference formats:**
 - `Closes #123`
@@ -47,8 +47,9 @@ This directory contains automated workflows that help manage the repository.
 
 These workflows help maintain consistency in labeling and automate project management:
 - **Consistency:** PRs inherit the same categorisation as their related issues
-- **Automation:** No manual effort required to copy labels or update issue status
+- **Automation:** No manual effort required to copy labels or update project status
 - **Organisation:** Better filtering and searching of PRs by label
 - **Tracking:** Easier to see what types of changes are in PRs
-- **Project Management:** Automatic task board updates based on issue assignment and PR creation
+- **Project Management:** Automatic GitHub Projects board updates based on issue assignment and PR creation
 - **Status Tracking:** Clear progression from assignment → In Progress → Code Review → Done
+- **Multi-Project Support:** Works across multiple GitHub Projects if issues are in several boards

--- a/.github/workflows/auto-move-assigned-issues.yml
+++ b/.github/workflows/auto-move-assigned-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Add In Progress label to assigned issues
+      - name: Update status to In Progress for assigned issues
         uses: actions/github-script@v7
         with:
           script: |
@@ -19,34 +19,135 @@ jobs:
             
             console.log(`Issue #${issue.number} assigned to ${assignee.login}`);
             
-            // Get current labels
-            const currentLabels = issue.labels.map(label => label.name);
-            console.log(`Current labels: ${currentLabels.join(', ')}`);
-            
-            // Status labels to manage
-            const statusLabels = ['In Progress', 'Code Review', 'Done'];
-            
-            // Remove existing status labels
-            const labelsToRemove = currentLabels.filter(label => statusLabels.includes(label));
-            for (const label of labelsToRemove) {
-              await github.rest.issues.removeLabel({
+            try {
+              // Update issue status to "In Progress" using GitHub Projects API
+              // First, get the project items for this issue
+              const query = `
+                query($owner: String!, $repo: String!, $issueNumber: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $issueNumber) {
+                      projectItems(first: 10) {
+                        nodes {
+                          id
+                          project {
+                            id
+                            title
+                          }
+                          fieldValues(first: 20) {
+                            nodes {
+                              ... on ProjectV2ItemFieldSingleSelectValue {
+                                id
+                                name
+                                field {
+                                  ... on ProjectV2SingleSelectField {
+                                    id
+                                    name
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+              
+              const variables = {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
-                name: label
-              });
-              console.log(`Removed '${label}' label from issue #${issue.number}`);
-            }
-            
-            // Add "In Progress" label if not already present
-            if (!currentLabels.includes('In Progress')) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                labels: ['In Progress']
-              });
-              console.log(`Added 'In Progress' label to issue #${issue.number}`);
-            } else {
-              console.log(`Issue #${issue.number} already has 'In Progress' label`);
+                issueNumber: issue.number
+              };
+              
+              const projectData = await github.graphql(query, variables);
+              const projectItems = projectData.repository.issue.projectItems.nodes;
+              
+              if (projectItems.length === 0) {
+                console.log(`Issue #${issue.number} is not in any projects`);
+                return;
+              }
+              
+              // Update status for each project the issue is in
+              for (const item of projectItems) {
+                // Find the Status field
+                const statusField = item.fieldValues.nodes.find(field => 
+                  field.field && field.field.name.toLowerCase() === 'status'
+                );
+                
+                console.log(`Current status in project "${item.project.title}": ${statusField ? statusField.name : 'No status'}`);
+                
+                if (!statusField || statusField.name !== 'In Progress') {
+                  // Get the project's status field options
+                  const projectQuery = `
+                    query($projectId: ID!) {
+                      node(id: $projectId) {
+                        ... on ProjectV2 {
+                          fields(first: 20) {
+                            nodes {
+                              ... on ProjectV2SingleSelectField {
+                                id
+                                name
+                                options {
+                                  id
+                                  name
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `;
+                  
+                  const projectInfo = await github.graphql(projectQuery, { projectId: item.project.id });
+                  const statusFieldInfo = projectInfo.node.fields.nodes.find(field => 
+                    field.name.toLowerCase() === 'status'
+                  );
+                  
+                  if (statusFieldInfo) {
+                    const inProgressOption = statusFieldInfo.options.find(option => 
+                      option.name === 'In Progress'
+                    );
+                    
+                    if (inProgressOption) {
+                      // Update the status
+                      const updateMutation = `
+                        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                          updateProjectV2ItemFieldValue(input: {
+                            projectId: $projectId
+                            itemId: $itemId
+                            fieldId: $fieldId
+                            value: $value
+                          }) {
+                            projectV2Item {
+                              id
+                            }
+                          }
+                        }
+                      `;
+                      
+                      await github.graphql(updateMutation, {
+                        projectId: item.project.id,
+                        itemId: item.id,
+                        fieldId: statusFieldInfo.id,
+                        value: {
+                          singleSelectOptionId: inProgressOption.id
+                        }
+                      });
+                      
+                      console.log(`Updated issue #${issue.number} status to "In Progress" in project "${item.project.title}"`);
+                    } else {
+                      console.log(`No "In Progress" option found in project "${item.project.title}"`);
+                    }
+                  } else {
+                    console.log(`No status field found in project "${item.project.title}"`);
+                  }
+                } else {
+                  console.log(`Issue #${issue.number} already has "In Progress" status in project "${item.project.title}"`);
+                }
+              }
+              
+            } catch (error) {
+              console.log(`Error updating issue #${issue.number}: ${error.message}`);
             }

--- a/.github/workflows/copy-issue-labels-to-pr.yml
+++ b/.github/workflows/copy-issue-labels-to-pr.yml
@@ -88,7 +88,7 @@ jobs:
               console.log('No new labels to add to PR');
             }
             
-            // Assign referenced issues to PR author and add "Code Review" label
+            // Assign referenced issues to PR author and update status to "Code Review"
             for (const issueNumber of issueNumbers) {
               try {
                 const issue = await github.rest.issues.get({
@@ -109,16 +109,119 @@ jobs:
                   console.log(`Assigned issue #${issueNumber} to ${pr.user.login}`);
                 }
                 
-                // Add "Code Review" label to issue if not present
-                const issueLabels = issue.data.labels.map(label => label.name);
-                if (!issueLabels.includes('Code Review')) {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    labels: ['Code Review']
-                  });
-                  console.log(`Added 'Code Review' label to issue #${issueNumber}`);
+                // Update issue status to "Code Review" using GitHub Projects API
+                // First, get the project items for this issue
+                const query = `
+                  query($owner: String!, $repo: String!, $issueNumber: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      issue(number: $issueNumber) {
+                        projectItems(first: 10) {
+                          nodes {
+                            id
+                            project {
+                              id
+                              title
+                            }
+                            fieldValues(first: 20) {
+                              nodes {
+                                ... on ProjectV2ItemFieldSingleSelectValue {
+                                  id
+                                  name
+                                  field {
+                                    ... on ProjectV2SingleSelectField {
+                                      id
+                                      name
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                `;
+                
+                const variables = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issueNumber: issueNumber
+                };
+                
+                const projectData = await github.graphql(query, variables);
+                const projectItems = projectData.repository.issue.projectItems.nodes;
+                
+                // Update status for each project the issue is in
+                for (const item of projectItems) {
+                  // Find the Status field
+                  const statusField = item.fieldValues.nodes.find(field => 
+                    field.field && field.field.name.toLowerCase() === 'status'
+                  );
+                  
+                  if (statusField && statusField.name !== 'Code Review') {
+                    // Get the project's status field options
+                    const projectQuery = `
+                      query($projectId: ID!) {
+                        node(id: $projectId) {
+                          ... on ProjectV2 {
+                            fields(first: 20) {
+                              nodes {
+                                ... on ProjectV2SingleSelectField {
+                                  id
+                                  name
+                                  options {
+                                    id
+                                    name
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    `;
+                    
+                    const projectInfo = await github.graphql(projectQuery, { projectId: item.project.id });
+                    const statusFieldInfo = projectInfo.node.fields.nodes.find(field => 
+                      field.name.toLowerCase() === 'status'
+                    );
+                    
+                    if (statusFieldInfo) {
+                      const codeReviewOption = statusFieldInfo.options.find(option => 
+                        option.name === 'Code Review'
+                      );
+                      
+                      if (codeReviewOption) {
+                        // Update the status
+                        const updateMutation = `
+                          mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                            updateProjectV2ItemFieldValue(input: {
+                              projectId: $projectId
+                              itemId: $itemId
+                              fieldId: $fieldId
+                              value: $value
+                            }) {
+                              projectV2Item {
+                                id
+                              }
+                            }
+                          }
+                        `;
+                        
+                        await github.graphql(updateMutation, {
+                          projectId: item.project.id,
+                          itemId: item.id,
+                          fieldId: statusFieldInfo.id,
+                          value: {
+                            singleSelectOptionId: codeReviewOption.id
+                          }
+                        });
+                        
+                        console.log(`Updated issue #${issueNumber} status to "Code Review" in project "${item.project.title}"`);
+                      }
+                    }
+                  }
                 }
                 
               } catch (error) {


### PR DESCRIPTION
- Changed both workflows to update Status column in GitHub Projects
- Use GraphQL API to properly update project status fields
- Support multiple projects if issue is in several boards
- Updated documentation to reflect Status vs Label distinction
- More robust error handling and logging

This correctly integrates with GitHub Projects task boards rather than just adding labels that don't update the visual board.