### PR TITLE
feat: simplify valproate YAML descriptions focusing on business logic

### DIFF
--- a/models/intermediate/programme/valproate/int_valproate_araf_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_araf_events.yml
@@ -1,40 +1,14 @@
 version: 2
 models:
 - name: int_valproate_araf_events
-  description: 'Intermediate: Valproate ARAF Events - Comprehensive collection of all Annual Risk Acknowledgement Form events for valproate patient safety monitoring.
+  description: 'Extracts all ARAF events from observations using valproate programme codes.
 
-
-    Clinical Purpose:
-
-    • Gathers all ARAF completion events for patients on valproate therapy
-
-    • Supports annual risk acknowledgement monitoring for valproate clinical safety
-
-    • Enables comprehensive tracking of ARAF completion with lookback logic applied
-
-    • Provides foundation data for valproate programme safety compliance and risk acknowledgement
-
-
-    Data Granularity:
-
-    • One row per ARAF event observation for patients on valproate therapy
-
-    • Applies lookback logic as defined in valproate programme codes for current relevance
-
-    • Includes specific ARAF form code identification flags for detailed analysis
-
-    • Contains clinical effective dates for temporal analysis and programme tracking
-
-
-    Key Features:
-
-    • ARAF code category filtering with specific form code identification
-
-    • Lookback logic application based on valproate programme code configuration
-
-    • Integration with valproate programme codes for comprehensive ARAF tracking
-
-    • Support for valproate patient safety monitoring and annual risk acknowledgement compliance'
+    Business Logic:
+    • Joins observations with mapped concepts and valproate programme codes
+    • Filters to ARAF code category only
+    • One row per ARAF observation with person, date, concept details
+    • Includes specific ARAF form code identification and lookback logic
+    • Foundation data for ARAF dimension aggregation'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/intermediate/programme/valproate/int_valproate_araf_referral_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_araf_referral_events.yml
@@ -1,40 +1,13 @@
 version: 2
 models:
 - name: int_valproate_araf_referral_events
-  description: 'Intermediate: Valproate ARAF Referral Events - Comprehensive collection of all ARAF referral events for valproate patient safety monitoring.
+  description: 'Extracts all ARAF referral events from observations using valproate programme codes.
 
-
-    Clinical Purpose:
-
-    • Gathers all ARAF referral events for patients on valproate therapy requiring specialist input
-
-    • Supports referral tracking for Annual Risk Acknowledgement Form completion
-
-    • Enables comprehensive monitoring of specialist referrals in valproate safety programme
-
-    • Provides foundation data for valproate programme referral pathway analysis
-
-
-    Data Granularity:
-
-    • One row per ARAF referral event observation for patients on valproate therapy
-
-    • Covers all referral-related observations using REFERRAL code category
-
-    • Includes clinical effective dates for temporal analysis and referral tracking
-
-    • Contains concept codes and descriptions for detailed referral documentation
-
-
-    Key Features:
-
-    • REFERRAL code category filtering for comprehensive referral event capture
-
-    • Integration with valproate programme codes for referral pathway tracking
-
-    • Support for specialist referral monitoring in valproate safety programme
-
-    • Foundation data for ARAF completion pathway analysis and referral outcomes'
+    Business Logic:
+    • Joins observations with mapped concepts and valproate programme codes
+    • Filters to REFERRAL code category only
+    • One row per ARAF referral observation with person, date, concept details
+    • Foundation data for ARAF referral dimension aggregation'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/intermediate/programme/valproate/int_valproate_neurology_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_neurology_events.yml
@@ -1,40 +1,13 @@
 version: 2
 models:
 - name: int_valproate_neurology_events
-  description: 'Intermediate: Valproate Neurology Events - Comprehensive collection of all neurology-related events for valproate patient safety monitoring.
+  description: 'Extracts all neurology-related events from observations using valproate programme codes.
 
-
-    Clinical Purpose:
-
-    • Gathers all neurology specialty events for patients on valproate therapy
-
-    • Supports neurology pathway tracking for valproate patient safety monitoring
-
-    • Enables comprehensive monitoring of neurological care in valproate safety programme
-
-    • Provides foundation data for valproate programme neurology specialty analysis
-
-
-    Data Granularity:
-
-    • One row per neurology event observation for patients on valproate therapy
-
-    • Covers all neurology-related observations using NEUROLOGY code category
-
-    • Includes clinical effective dates for temporal analysis and neurology pathway tracking
-
-    • Contains concept codes and descriptions for detailed neurology event documentation
-
-
-    Key Features:
-
-    • NEUROLOGY code category filtering for comprehensive neurology event capture
-
-    • Integration with valproate programme codes for neurology pathway tracking
-
-    • Support for neurology specialty monitoring in valproate safety programme
-
-    • Foundation data for neurological care pathway analysis in valproate patients'
+    Business Logic:
+    • Joins observations with mapped concepts and valproate programme codes
+    • Filters to NEUROLOGY code category only
+    • One row per neurology observation with person, date, concept details
+    • Foundation data for neurology dimension aggregation'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/intermediate/programme/valproate/int_valproate_psychiatry_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_psychiatry_events.yml
@@ -1,40 +1,13 @@
 version: 2
 models:
 - name: int_valproate_psychiatry_events
-  description: 'Intermediate: Valproate Psychiatry Events - Comprehensive collection of all psychiatry-related events for valproate patient safety monitoring.
+  description: 'Extracts all psychiatry-related events from observations using valproate programme codes.
 
-
-    Clinical Purpose:
-
-    • Gathers all psychiatry specialty events for patients on valproate therapy
-
-    • Supports psychiatry pathway tracking for valproate patient safety monitoring
-
-    • Enables comprehensive monitoring of psychiatric care in valproate safety programme
-
-    • Provides foundation data for valproate programme psychiatry specialty analysis
-
-
-    Data Granularity:
-
-    • One row per psychiatry event observation for patients on valproate therapy
-
-    • Covers all psychiatry-related observations using PSYCH code category
-
-    • Includes clinical effective dates for temporal analysis and psychiatry pathway tracking
-
-    • Contains concept codes and descriptions for detailed psychiatry event documentation
-
-
-    Key Features:
-
-    • PSYCH code category filtering for comprehensive psychiatry event capture
-
-    • Integration with valproate programme codes for psychiatry pathway tracking
-
-    • Support for psychiatry specialty monitoring in valproate safety programme
-
-    • Foundation data for psychiatric care pathway analysis in valproate patients'
+    Business Logic:
+    • Joins observations with mapped concepts and valproate programme codes
+    • Filters to PSYCH code category only
+    • One row per psychiatry observation with person, date, concept details
+    • Foundation data for psychiatry dimension aggregation'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_action_status.yml
+++ b/models/marts/programme/valproate/dim_valproate_action_status.yml
@@ -1,25 +1,13 @@
 version: 2
 models:
 - name: dim_valproate_action_status
-  description: 'Mart: Valproate Action Status - Clinical decision support for valproate safety monitoring with recommended actions based on patient status.
+  description: 'Clinical decision support table implementing valproate safety monitoring logic with recommended actions.
 
-
-    Population Scope:
-
-    • Patients on valproate therapy requiring safety monitoring
-
-    • Women of childbearing age (0-55 years) with valproate prescriptions
-
-    • Includes all patients with valproate medication orders and clinical dependencies
-
-
-    Key Features:
-
-    • Clinical decision logic for safety monitoring and intervention recommendations
-
-    • Comprehensive status assessment including PPP status and clinical dependencies
-
-    • Evidence-based action recommendations supporting regulatory compliance'
+    Business Logic:
+    • Joins database scope with all dimension tables (PPP, ARAF, referrals, specialists, pregnancy)
+    • Implements CASE-based decision logic for recommended actions based on patient status
+    • Actions include: pregnancy review, PPP enrollment check, ARAF compliance, specialist monitoring
+    • Provides consolidated view of all patient safety monitoring dimensions for decision support'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_araf.yml
+++ b/models/marts/programme/valproate/dim_valproate_araf.yml
@@ -1,25 +1,14 @@
 version: 2
 models:
 - name: dim_valproate_araf
-  description: 'Mart: Valproate ARAF Status - Person-level aggregation of Annual Risk Acknowledgement Form events for valproate safety monitoring.
+  description: 'Person-level aggregation of Annual Risk Acknowledgement Form (ARAF) events for valproate monitoring.
 
-
-    Population Scope:
-
-    • Patients with ARAF-related events in valproate safety monitoring
-
-    • All persons with recorded Annual Risk Acknowledgement Form interactions
-
-    • One row per person with ARAF events and completion tracking
-
-
-    Key Features:
-
-    • Person-level ARAF event aggregation with complete compliance history
-
-    • Earliest and latest ARAF completion tracking for monitoring effectiveness
-
-    • Evidence-based ARAF compliance assessment supporting regulatory requirements'
+    Business Logic:
+    • Aggregates all ARAF events per person from intermediate ARAF events table
+    • Provides earliest and latest ARAF event dates for timeline analysis
+    • Tracks latest specific ARAF form date and lookback compliance flag
+    • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    • Only includes people who have ARAF events (has_araf_event always TRUE)'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_araf_referral.yml
+++ b/models/marts/programme/valproate/dim_valproate_araf_referral.yml
@@ -1,38 +1,13 @@
 version: 2
 models:
 - name: dim_valproate_araf_referral
-  description: 'Mart: Valproate ARAF Referral Status - Person-level aggregation of ARAF referral events for valproate safety monitoring compliance.
+  description: 'Person-level aggregation of ARAF referral events for valproate monitoring.
 
-
-    Business Purpose:
-
-    • Support valproate safety monitoring through ARAF referral tracking and specialist engagement
-
-    • Enable systematic monitoring of specialist referral requirements for valproate therapy oversight
-
-    • Provide clinical decision support for ARAF referral compliance and specialist involvement
-
-    • Support quality improvement initiatives for comprehensive valproate safety programme delivery
-
-
-    Data Granularity:
-
-    • One row per person with ARAF referral events in valproate safety monitoring
-
-    • Aggregates all ARAF referral events with earliest and latest referral tracking
-
-    • Includes comprehensive referral history for specialist engagement monitoring
-
-
-    Key Features:
-
-    • Person-level ARAF referral event aggregation with complete specialist engagement history
-
-    • Earliest and latest referral tracking for monitoring specialist involvement effectiveness
-
-    • Evidence-based referral compliance assessment supporting comprehensive safety monitoring
-
-    • Integration with valproate safety pathways for systematic specialist engagement coordination'
+    Business Logic:
+    • Aggregates all ARAF referral events per person from intermediate ARAF referral events table
+    • Provides earliest and latest ARAF referral event dates for timeline analysis
+    • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    • Only includes people who have ARAF referral events (has_araf_referral_event always TRUE)'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_db_scope.yml
+++ b/models/marts/programme/valproate/dim_valproate_db_scope.yml
@@ -1,38 +1,12 @@
 version: 2
 models:
 - name: dim_valproate_db_scope
-  description: 'Mart: Valproate Database Scope - Defines cohort of non-male individuals aged 0-55 with recent valproate prescriptions requiring safety monitoring.
+  description: 'Dashboard scope table - every row should be included in the valproate monitoring dashboard.
 
-
-    Business Purpose:
-
-    • Support valproate safety monitoring programme by defining target population for regulatory compliance
-
-    • Enable systematic identification of patients requiring valproate-related safety interventions
-
-    • Provide clinical decision support for valproate prescribing safety in reproductive-age populations
-
-    • Support quality improvement initiatives for medication safety and teratogenicity risk management
-
-
-    Data Granularity:
-
-    • One row per non-male person aged 0-55 with valproate prescription in last 6 months
-
-    • Includes most recent valproate prescription details and patient demographics
-
-    • Limited to target population requiring valproate safety monitoring and intervention
-
-
-    Key Features:
-
-    • Age and gender-based cohort definition (non-male, 0-55 years) for appropriate safety monitoring
-
-    • Recent prescription tracking (6 months) for current valproate therapy identification
-
-    • Evidence-based cohort criteria supporting regulatory compliance and patient safety
-
-    • Integration with valproate safety monitoring pathways for systematic patient management'
+    Business Logic:
+    • Joins child-bearing age cohort (non-male, 0-55 years) with recent valproate prescriptions (last 6 months)
+    • One row per person with their most recent valproate prescription details
+    • Only includes patients meeting both criteria: correct age/gender AND recent valproate therapy'
   columns:
   - name: person_id
     description: Unique identifier for a person

--- a/models/marts/programme/valproate/dim_valproate_neurology.yml
+++ b/models/marts/programme/valproate/dim_valproate_neurology.yml
@@ -1,38 +1,13 @@
 version: 2
 models:
 - name: dim_valproate_neurology
-  description: 'Mart: Valproate Neurology Status - Person-level aggregation of neurology-related events for valproate therapy monitoring and specialist care coordination.
+  description: 'Person-level aggregation of neurology-related events for valproate monitoring.
 
-
-    Business Purpose:
-
-    • Support valproate safety monitoring through neurology specialist engagement tracking and care coordination
-
-    • Enable systematic monitoring of neurological care requirements for valproate therapy management
-
-    • Provide clinical decision support for neurology specialist involvement and treatment oversight
-
-    • Support quality improvement initiatives for comprehensive neurological care and medication safety
-
-
-    Data Granularity:
-
-    • One row per person with neurology-related events in valproate therapy monitoring
-
-    • Aggregates all neurology events with earliest and latest specialist engagement tracking
-
-    • Includes comprehensive neurology care history for specialist coordination assessment
-
-
-    Key Features:
-
-    • Person-level neurology event aggregation with complete specialist care history
-
-    • Earliest and latest neurology engagement tracking for monitoring care coordination effectiveness
-
-    • Evidence-based neurology care assessment supporting comprehensive valproate therapy management
-
-    • Integration with neurology care pathways for systematic specialist engagement and monitoring'
+    Business Logic:
+    • Aggregates all neurology events per person from intermediate neurology events table
+    • Provides earliest and latest neurology event dates for timeline analysis
+    • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    • Only includes people who have neurology events (has_neurology_event always TRUE)'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_ppp_status.yml
+++ b/models/marts/programme/valproate/dim_valproate_ppp_status.yml
@@ -1,38 +1,14 @@
 version: 2
 models:
 - name: dim_valproate_ppp_status
-  description: 'Mart: Valproate PPP Status - Person-level aggregation of Pregnancy Prevention Programme events for valproate safety monitoring and reproductive health management.
+  description: 'Person-level aggregation of Pregnancy Prevention Programme (PPP) events for valproate monitoring.
 
-
-    Business Purpose:
-
-    • Support valproate safety monitoring through Pregnancy Prevention Programme compliance tracking
-
-    • Enable systematic monitoring of reproductive health safeguards for valproate therapy in women
-
-    • Provide clinical decision support for PPP compliance and contraceptive counselling
-
-    • Support quality improvement initiatives for teratogenicity prevention and reproductive safety
-
-
-    Data Granularity:
-
-    • One row per person with PPP-related events in valproate safety monitoring
-
-    • Aggregates all PPP events with comprehensive reproductive health safeguard tracking
-
-    • Includes complete PPP compliance history for reproductive safety assessment
-
-
-    Key Features:
-
-    • Person-level PPP event aggregation with complete reproductive health safeguard history
-
-    • Comprehensive PPP compliance tracking for monitoring pregnancy prevention effectiveness
-
-    • Evidence-based PPP assessment supporting regulatory compliance and reproductive safety
-
-    • Integration with reproductive health pathways for systematic pregnancy prevention management'
+    Business Logic:
+    • Aggregates all PPP events per person from intermediate PPP status table
+    • Determines latest PPP status and enrollment (is_currently_ppp_enrolled from most recent event)
+    • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    • Provides current PPP status description with formatted date
+    • Only includes people who have PPP events (has_ppp_event always TRUE)'
   columns:
   - name: person_id
     description: Unique identifier for the person.

--- a/models/marts/programme/valproate/dim_valproate_psychiatry.yml
+++ b/models/marts/programme/valproate/dim_valproate_psychiatry.yml
@@ -1,38 +1,13 @@
 version: 2
 models:
 - name: dim_valproate_psychiatry
-  description: 'Mart: Valproate Psychiatry Status - Person-level aggregation of psychiatry-related events for valproate therapy monitoring and mental health care coordination.
+  description: 'Person-level aggregation of psychiatry-related events for valproate monitoring.
 
-
-    Business Purpose:
-
-    • Support valproate safety monitoring through psychiatry specialist engagement tracking and care coordination
-
-    • Enable systematic monitoring of mental health care requirements for valproate therapy management
-
-    • Provide clinical decision support for psychiatry specialist involvement and treatment oversight
-
-    • Support quality improvement initiatives for comprehensive mental health care and medication safety
-
-
-    Data Granularity:
-
-    • One row per person with psychiatry-related events in valproate therapy monitoring
-
-    • Aggregates all psychiatry events with earliest and latest specialist engagement tracking
-
-    • Includes comprehensive psychiatry care history for specialist coordination assessment
-
-
-    Key Features:
-
-    • Person-level psychiatry event aggregation with complete mental health specialist care history
-
-    • Earliest and latest psychiatry engagement tracking for monitoring care coordination effectiveness
-
-    • Evidence-based psychiatry care assessment supporting comprehensive valproate therapy management
-
-    • Integration with mental health care pathways for systematic specialist engagement and monitoring'
+    Business Logic:
+    • Aggregates all psychiatry events per person from intermediate psychiatry events table
+    • Provides earliest and latest psychiatry event dates for timeline analysis
+    • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    • Only includes people who have psychiatry events (has_psych_event always TRUE)'
   columns:
   - name: person_id
     description: Unique identifier for the person.


### PR DESCRIPTION
## Summary
- Simplify lengthy business purpose sections in valproate YAML descriptions
- Focus on concise business logic explanations rather than verbose purpose statements
- Emphasise dashboard scope context for dim_valproate_db_scope table

## Changes Made
- Condensed business purpose sections into technical business logic explanations
- Removed repetitive business purpose headers across all valproate dimension tables
- Updated intermediate table descriptions to focus on code category filtering logic
- All descriptions now reflect actual SQL implementation rather than abstract purposes

## Files Modified
- All dim_valproate_* YAML files in marts/programme/valproate/
- All int_valproate_* YAML files in intermediate/programme/valproate/

## Test Plan
- [ ] Verify YAML files are valid and parseable
- [ ] Confirm descriptions accurately reflect SQL logic
- [ ] Check that dashboard scope context is clear for dim_valproate_db_scope