### PR TITLE
fix: add proper line breaks between bullet points in valproate YAML descriptions

### DIFF
--- a/models/intermediate/programme/valproate/int_valproate_araf_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_araf_events.yml
@@ -4,10 +4,15 @@ models:
   description: 'Extracts all ARAF events from observations using valproate programme codes.
 
     Business Logic:
+    
     • Joins observations with mapped concepts and valproate programme codes
+    
     • Filters to ARAF code category only
+    
     • One row per ARAF observation with person, date, concept details
+    
     • Includes specific ARAF form code identification and lookback logic
+    
     • Foundation data for ARAF dimension aggregation'
   columns:
   - name: person_id

--- a/models/intermediate/programme/valproate/int_valproate_araf_referral_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_araf_referral_events.yml
@@ -4,9 +4,13 @@ models:
   description: 'Extracts all ARAF referral events from observations using valproate programme codes.
 
     Business Logic:
+    
     • Joins observations with mapped concepts and valproate programme codes
+    
     • Filters to REFERRAL code category only
+    
     • One row per ARAF referral observation with person, date, concept details
+    
     • Foundation data for ARAF referral dimension aggregation'
   columns:
   - name: person_id

--- a/models/intermediate/programme/valproate/int_valproate_neurology_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_neurology_events.yml
@@ -4,9 +4,13 @@ models:
   description: 'Extracts all neurology-related events from observations using valproate programme codes.
 
     Business Logic:
+    
     • Joins observations with mapped concepts and valproate programme codes
+    
     • Filters to NEUROLOGY code category only
+    
     • One row per neurology observation with person, date, concept details
+    
     • Foundation data for neurology dimension aggregation'
   columns:
   - name: person_id

--- a/models/intermediate/programme/valproate/int_valproate_psychiatry_events.yml
+++ b/models/intermediate/programme/valproate/int_valproate_psychiatry_events.yml
@@ -4,9 +4,13 @@ models:
   description: 'Extracts all psychiatry-related events from observations using valproate programme codes.
 
     Business Logic:
+    
     • Joins observations with mapped concepts and valproate programme codes
+    
     • Filters to PSYCH code category only
+    
     • One row per psychiatry observation with person, date, concept details
+    
     • Foundation data for psychiatry dimension aggregation'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_action_status.yml
+++ b/models/marts/programme/valproate/dim_valproate_action_status.yml
@@ -4,9 +4,13 @@ models:
   description: 'Clinical decision support table implementing valproate safety monitoring logic with recommended actions.
 
     Business Logic:
+    
     • Joins database scope with all dimension tables (PPP, ARAF, referrals, specialists, pregnancy)
+    
     • Implements CASE-based decision logic for recommended actions based on patient status
+    
     • Actions include: pregnancy review, PPP enrollment check, ARAF compliance, specialist monitoring
+    
     • Provides consolidated view of all patient safety monitoring dimensions for decision support'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_araf.yml
+++ b/models/marts/programme/valproate/dim_valproate_araf.yml
@@ -4,10 +4,15 @@ models:
   description: 'Person-level aggregation of Annual Risk Acknowledgement Form (ARAF) events for valproate monitoring.
 
     Business Logic:
+    
     • Aggregates all ARAF events per person from intermediate ARAF events table
+    
     • Provides earliest and latest ARAF event dates for timeline analysis
+    
     • Tracks latest specific ARAF form date and lookback compliance flag
+    
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    
     • Only includes people who have ARAF events (has_araf_event always TRUE)'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_araf_referral.yml
+++ b/models/marts/programme/valproate/dim_valproate_araf_referral.yml
@@ -4,9 +4,13 @@ models:
   description: 'Person-level aggregation of ARAF referral events for valproate monitoring.
 
     Business Logic:
+    
     • Aggregates all ARAF referral events per person from intermediate ARAF referral events table
+    
     • Provides earliest and latest ARAF referral event dates for timeline analysis
+    
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    
     • Only includes people who have ARAF referral events (has_araf_referral_event always TRUE)'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_db_scope.yml
+++ b/models/marts/programme/valproate/dim_valproate_db_scope.yml
@@ -4,8 +4,11 @@ models:
   description: 'Dashboard scope table - every row should be included in the valproate monitoring dashboard.
 
     Business Logic:
+    
     • Joins child-bearing age cohort (non-male, 0-55 years) with recent valproate prescriptions (last 6 months)
+    
     • One row per person with their most recent valproate prescription details
+    
     • Only includes patients meeting both criteria: correct age/gender AND recent valproate therapy'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_neurology.yml
+++ b/models/marts/programme/valproate/dim_valproate_neurology.yml
@@ -4,9 +4,13 @@ models:
   description: 'Person-level aggregation of neurology-related events for valproate monitoring.
 
     Business Logic:
+    
     • Aggregates all neurology events per person from intermediate neurology events table
+    
     • Provides earliest and latest neurology event dates for timeline analysis
+    
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    
     • Only includes people who have neurology events (has_neurology_event always TRUE)'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_ppp_status.yml
+++ b/models/marts/programme/valproate/dim_valproate_ppp_status.yml
@@ -4,10 +4,15 @@ models:
   description: 'Person-level aggregation of Pregnancy Prevention Programme (PPP) events for valproate monitoring.
 
     Business Logic:
+    
     • Aggregates all PPP events per person from intermediate PPP status table
+    
     • Determines latest PPP status and enrollment (is_currently_ppp_enrolled from most recent event)
+    
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    
     • Provides current PPP status description with formatted date
+    
     • Only includes people who have PPP events (has_ppp_event always TRUE)'
   columns:
   - name: person_id

--- a/models/marts/programme/valproate/dim_valproate_psychiatry.yml
+++ b/models/marts/programme/valproate/dim_valproate_psychiatry.yml
@@ -4,9 +4,13 @@ models:
   description: 'Person-level aggregation of psychiatry-related events for valproate monitoring.
 
     Business Logic:
+    
     • Aggregates all psychiatry events per person from intermediate psychiatry events table
+    
     • Provides earliest and latest psychiatry event dates for timeline analysis
+    
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
+    
     • Only includes people who have psychiatry events (has_psych_event always TRUE)'
   columns:
   - name: person_id


### PR DESCRIPTION
## Summary
Follow-up fix to PR #71 to ensure proper bullet point formatting in valproate YAML descriptions.

## Changes Made
- Add blank lines between bullet points in Business Logic sections
- Ensures proper rendering when displayed in DBT documentation
- Prevents bullet points from running together in a single line

## Files Modified
- All dim_valproate_* YAML files in marts/programme/valproate/
- All int_valproate_* YAML files in intermediate/programme/valproate/

## Test Plan
- [x] Verify YAML files are valid and parseable
- [x] Confirm bullet points display with proper line breaks in DBT docs
- [x] Check that Business Logic sections are well-formatted

## Related
- Follow-up to PR #71 which simplified the business purpose descriptions