### PR TITLE
fix: ensure dim_person_current_practice has exactly 1 row per person and supports incremental loading

### DIFF
--- a/models/marts/organisation/dim_person_current_practice.sql
+++ b/models/marts/organisation/dim_person_current_practice.sql
@@ -7,13 +7,48 @@
 
 -- Person Current Practice Dimension Table
 -- Simple view of current practice registrations from historical practice table
+-- Ensures exactly one row per person with valid person_id
+
+WITH current_registrations AS (
+    SELECT
+        person_id,
+        sk_patient_id,
+        practice_id,
+        practice_code,
+        practice_name,
+        practice_type_code,
+        practice_type_desc,
+        practice_postcode,
+        practice_parent_org_id,
+        practice_open_date,
+        practice_close_date,
+        practice_is_obsolete,
+        registration_start_date,
+        registration_end_date,
+        registration_duration_days,
+        registration_sequence,
+        total_registrations_count,
+        has_changed_practice,
+        age_at_registration_start,
+        care_manager_practitioner_id,
+        -- Add row number to handle potential duplicates
+        ROW_NUMBER() OVER (
+            PARTITION BY person_id 
+            ORDER BY registration_start_date DESC, practice_id
+        ) AS rn
+    FROM {{ ref('dim_person_historical_practice') }}
+    WHERE is_current_registration = TRUE  -- person_id filtering handled upstream
+)
 
 SELECT
+    -- Core identifiers
     person_id,
     sk_patient_id,
     practice_id,
     practice_code,
     practice_name,
+    
+    -- Practice details
     practice_type_code,
     practice_type_desc,
     practice_postcode,
@@ -21,7 +56,17 @@ SELECT
     practice_open_date,
     practice_close_date,
     practice_is_obsolete,
+    
+    -- Registration details
     registration_start_date,
-    registration_end_date
-FROM {{ ref('dim_person_historical_practice') }}
-WHERE is_current_registration = TRUE
+    registration_end_date,
+    registration_duration_days,
+    registration_sequence,
+    total_registrations_count,
+    has_changed_practice,
+    
+    -- Additional useful fields
+    age_at_registration_start,
+    care_manager_practitioner_id
+FROM current_registrations
+WHERE rn = 1  -- Ensure only one row per person

--- a/models/marts/organisation/dim_person_historical_practice.sql
+++ b/models/marts/organisation/dim_person_historical_practice.sql
@@ -40,9 +40,6 @@ WITH enriched_registrations AS (
         -- Additional registration analysis
         CASE
             WHEN ipr.registration_end_date IS NULL THEN 'Open Registration'
-            WHEN
-                ipr.registration_end_date > CURRENT_DATE()
-                THEN 'Future End Date'
             ELSE 'Closed Registration'
         END AS registration_type,
         -- Calculate age at registration start (approximate)
@@ -55,6 +52,7 @@ WITH enriched_registrations AS (
         ON ipr.organisation_id = o.id
     LEFT JOIN {{ ref('stg_olids_patient') }} AS p
         ON ipr.patient_id = p.id
+    -- person_id filtering handled upstream in int_patient_registrations
 ),
 
 registration_transitions AS (

--- a/models/marts/organisation/dim_person_historical_practice.yml
+++ b/models/marts/organisation/dim_person_historical_practice.yml
@@ -50,12 +50,13 @@ models:
   - name: registration_end_date
     description: End date of registration (NULL if current)
   - name: registration_duration_days
-    description: Duration of registration in days
+    description: Duration of registration in days (NULL for active registrations)
 
     tests:
     - dbt_utils.accepted_range:
         min_value: 0
         max_value: 50000
+        where: "registration_end_date IS NOT NULL"
   - name: registration_sequence
     description: Sequence number of this registration for the person (1 = first practice)
 


### PR DESCRIPTION
## Summary
• Fixed dim_person_current_practice to ensure exactly 1 row per person
• Removed CURRENT_DATE() calculations across all models to support incremental loading
• Improved column structure and ordering for better usability

## Changes Made

### 1. int_patient_registrations
- Removed CURRENT_DATE() from is_current_registration logic (now based on NULL end dates)
- Removed CURRENT_DATE() from registration_duration_days calculation
- Removed CURRENT_DATE() from effective_end_date logic
- Simplified registration_status to Active/Historical only
- Added person_id filtering to ensure only valid person records

### 2. dim_person_historical_practice
- Removed CURRENT_DATE() from registration_type logic
- Simplified registration_type to Open/Closed only
- Removed redundant person_id filtering (handled upstream)

### 3. dim_person_current_practice
- Added ROW_NUMBER() deduplication to ensure exactly 1 row per person
- Added additional useful columns for analysis
- Improved column ordering with logical grouping
- Enhanced documentation

### 4. Test Updates
- Updated registration_duration_days test to handle NULL values properly
- Added WHERE clause to only test completed registrations

## Benefits
- **Incremental loading compatible**: All models now deterministic, no CURRENT_DATE() dependencies
- **Data quality**: Guarantees exactly 1 row per person in current practice table
- **Performance**: More efficient queries without dynamic date calculations
- **Maintainability**: Cleaner, more predictable logic

## Test Plan
- [x] All models compile successfully
- [x] Data quality tests pass
- [x] Unique constraint on person_id validated
- [x] NULL person_id values properly filtered

Fixes #80