### PR TITLE
fix: set Medicus Select Care practices to Enfield borough

### DIFF
--- a/models/intermediate/organisation/int_organisation_borough_mapping.sql
+++ b/models/intermediate/organisation/int_organisation_borough_mapping.sql
@@ -9,6 +9,10 @@
 Organisation Borough Mapping
 Maps practices and PCNs to North Central London boroughs based on historic CCG relationships.
 Uses Dictionary.dbo.OrganisationDescendent to trace organisational hierarchy paths.
+
+Special handling:
+- Medicus Select Care (Y03103) manually assigned to Enfield borough regardless of CCG history,
+  as they provide cross-borough services but parent organisation is Enfield-based.
 */
 
 WITH borough_ccgs AS (
@@ -41,10 +45,16 @@ practice_borough_final AS (
     -- Get final practice-to-borough mapping (one borough per practice)
     SELECT 
         practice_code,
-        borough,
+        CASE 
+            -- Special exception for Medicus Select Care - manually set to Enfield
+            WHEN practice_code = 'Y03103' THEN 'Enfield'
+            ELSE borough
+        END AS borough,
         historic_ccg
     FROM practice_borough_mapping
     WHERE rn = 1
+        -- For Medicus Select Care, only take the Enfield mapping to avoid duplicates
+        AND (practice_code != 'Y03103' OR borough = 'Enfield')
 ),
 
 pcn_borough_mapping AS (


### PR DESCRIPTION
## Summary
• Add manual override for Medicus Select Care (practice code Y03103) to consistently map to Enfield borough
• Resolve awkward multiple borough mappings that were causing reporting issues
• Align with parent organisation location (Medicus Health Partners in Enfield)

## Problem Solved
Medicus Select Care practices were getting mapped to multiple boroughs through historic CCG relationships, creating inconsistent reporting. These practices provide cross-borough services to patients removed from other practices due to violence, but need a single borough assignment for clean reporting.

## Implementation
- Manual CASE statement override in `int_organisation_borough_mapping.sql` 
- Filter logic to prevent duplicate rows for practice Y03103
- Updated documentation explaining the special handling rationale

## Test Plan
- [x] Single borough assignment for Medicus Select Care practices
- [x] No impact on other practice borough mappings
- [x] PCN borough assignments updated accordingly
- [x] Model compiles and runs successfully

## Benefits
• Consistent single borough assignment for Medicus practices
• Cleaner reporting without awkward multiple borough scenarios  
• Aligns with business logic (parent org location in Enfield)
• Maintains data integrity for all other practices

Fixes #84