### PR TITLE
fix: add missing key fields to valproate models

### DIFF
--- a/models/marts/programme/valproate/dim_valproate_action_status.sql
+++ b/models/marts/programme/valproate/dim_valproate_action_status.sql
@@ -26,60 +26,131 @@ psychiatry AS (
     SELECT * FROM {{ ref('dim_valproate_psychiatry') }}
 ),
 
-preg AS (
+pregnancy_status AS (
+    SELECT
+        p.person_id,
+        
+        -- Pregnancy logic: recent pregnancy code (last 9 months) after any delivery code
+        COALESCE(
+            preg.latest_preg_date IS NOT NULL
+            AND preg.latest_preg_date >= DATEADD(MONTH, -9, CURRENT_DATE())
+            AND (
+                preg.latest_delivery_date IS NULL
+                OR preg.latest_preg_date > preg.latest_delivery_date
+            ), FALSE
+        ) AS is_currently_pregnant,
+        
+        -- Permanent absence of pregnancy risk flag
+        COALESCE(perm.person_id IS NOT NULL, FALSE) AS has_permanent_absence_of_pregnancy_risk
+        
+    FROM {{ ref('dim_person') }} AS p
+    INNER JOIN {{ ref('dim_person_sex') }} AS sex ON p.person_id = sex.person_id
+    LEFT JOIN (
+        SELECT
+            person_id,
+            MAX(CASE WHEN is_pregnancy_code = TRUE THEN clinical_effective_date END) AS latest_preg_date,
+            MAX(CASE WHEN is_pregnancy_outcome_code = TRUE THEN clinical_effective_date END) AS latest_delivery_date
+        FROM {{ ref('int_pregnancy_status_all') }}
+        GROUP BY person_id
+    ) AS preg ON p.person_id = preg.person_id
+    LEFT JOIN (
+        SELECT DISTINCT person_id
+        FROM {{ ref('int_pregnancy_absence_risk_all') }}
+    ) AS perm ON p.person_id = perm.person_id
+    WHERE sex.sex != 'Male' -- Only non-male individuals
+),
+
+learning_disability AS (
     SELECT
         person_id,
-        is_currently_pregnant
-    FROM {{ ref('fct_person_pregnancy_status') }}
+        is_on_register
+    FROM {{ ref('fct_person_learning_disability_register') }}
 )
 
 SELECT
     db.person_id,
     db.age,
     db.sex,
-    db.is_child_bearing_age_0_55,
-    preg.is_currently_pregnant AS is_pregnant,
-    ppp.has_ppp_event,
-    -- PPP
-    ppp.is_currently_ppp_enrolled,
-    ppp.current_ppp_status_description,
-    araf.has_araf_event,
-    -- ARAF
-    araf.has_specific_araf_form_meeting_lookback,
-    arref.has_araf_referral_event,
-    -- ARAF Referral
-    neu.has_neurology_event,
-    -- Neurology
-    psych.has_psych_event,
-    -- Psychiatry
-    db.valproate_medication_order_id IS NOT NULL
-        AS has_recent_valproate_medication,
-    -- Action logic (simplified for demonstration)
+    
+    -- PPP Status
+    COALESCE(ppp.has_ppp_event, FALSE) AS has_ppp_status,
+    COALESCE(ppp.is_currently_ppp_enrolled, FALSE) AS is_ppp_enrolled,
+    COALESCE(ppp.is_ppp_non_enrolled, FALSE) AS is_ppp_non_enrolled,
+    COALESCE(ppp.current_ppp_status_description, 'No - No entry found') AS ppp_status_description,
+    
+    -- ARAF Status
+    COALESCE(araf.has_araf_event, FALSE) AS has_araf_event,
+    COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) AS has_current_araf,
+    
+    -- Risk Assessment Flags
+    COALESCE(preg_status.has_permanent_absence_of_pregnancy_risk, FALSE) AS has_permanent_absence_pregnancy_risk,
+    COALESCE(ld.is_on_register, FALSE) AS has_learning_disability,
+    COALESCE(preg_status.is_currently_pregnant, FALSE) AS has_pregnancy,
+    
+    -- Condition Flags
+    COALESCE(neu.has_neurology_event, FALSE) AS has_neurology,
+    COALESCE(psych.has_psych_event, FALSE) AS has_psychiatry,
+    
+    -- Risk of Pregnancy Classification
     CASE
-        WHEN is_pregnant THEN 'Review or refer: Pregnancy detected'
-        WHEN
-            NOT has_recent_valproate_medication
-            THEN 'No action: Not on valproate'
-        WHEN
-            NOT db.is_child_bearing_age_0_55
-            THEN 'No action: Not woman of child-bearing age'
-        WHEN
-            NOT ppp.is_currently_ppp_enrolled
-            THEN 'Review: Not enrolled in PPP'
-        WHEN
-            NOT araf.has_specific_araf_form_meeting_lookback
-            THEN 'Review: ARAF not completed in lookback'
-        WHEN arref.has_araf_referral_event THEN 'Monitor: Referral made'
-        WHEN
-            neu.has_neurology_event OR psych.has_psych_event
-            THEN 'Monitor: Under specialist care'
-        ELSE 'No action needed'
-    END AS recommended_action
+        WHEN db.age BETWEEN 0 AND 6 OR COALESCE(preg_status.has_permanent_absence_of_pregnancy_risk, FALSE) = TRUE THEN 'Low Risk'
+        WHEN db.age BETWEEN 7 AND 12 THEN 'Medium Risk'
+        ELSE 'High Risk'
+    END AS risk_of_pregnancy,
+    
+    -- Action determination matching original logic exactly
+    CASE
+        WHEN COALESCE(preg_status.is_currently_pregnant, FALSE) = TRUE THEN 'Review or refer'
+        WHEN db.age BETWEEN 0 AND 6 OR COALESCE(preg_status.has_permanent_absence_of_pregnancy_risk, FALSE) = TRUE THEN 'No action required'
+        WHEN COALESCE(ppp.is_ppp_non_enrolled, FALSE) = TRUE THEN 'Keep under review'
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND COALESCE(ld.is_on_register, FALSE) = TRUE) THEN 'Review or refer'
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND db.age BETWEEN 13 AND 60) THEN 'Review or refer'
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND db.age BETWEEN 7 AND 12) THEN 'Review or refer'
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 7 AND 60 AND COALESCE(ld.is_on_register, FALSE) = TRUE THEN 'Consider expiry of ARAF'
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 7 AND 12 THEN 'Consider expiry of ARAF'
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 13 AND 60 THEN 'Consider expiry of ARAF'
+        ELSE 'Review or refer'
+    END AS action,
+    
+    -- Action priority order matching original logic exactly
+    CASE
+        WHEN COALESCE(preg_status.is_currently_pregnant, FALSE) = TRUE THEN 1
+        WHEN db.age BETWEEN 0 AND 6 OR COALESCE(preg_status.has_permanent_absence_of_pregnancy_risk, FALSE) = TRUE THEN 9
+        WHEN COALESCE(ppp.is_ppp_non_enrolled, FALSE) = TRUE THEN 5
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND COALESCE(ld.is_on_register, FALSE) = TRUE) THEN 2
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND db.age BETWEEN 13 AND 60) THEN 3
+        WHEN COALESCE(ppp.has_ppp_event, FALSE) = FALSE OR (COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = FALSE AND db.age BETWEEN 7 AND 12) THEN 4
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 7 AND 60 AND COALESCE(ld.is_on_register, FALSE) = TRUE THEN 6
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 7 AND 12 THEN 7
+        WHEN COALESCE(ppp.is_currently_ppp_enrolled, FALSE) = TRUE AND COALESCE(araf.has_specific_araf_form_meeting_lookback, FALSE) = TRUE AND db.age BETWEEN 13 AND 60 THEN 8
+        ELSE NULL
+    END AS action_order,
+    
+    -- Additional findings grouping
+    CASE
+        WHEN COALESCE(preg_status.is_currently_pregnant, FALSE) = FALSE AND COALESCE(ld.is_on_register, FALSE) = FALSE THEN ''
+        WHEN COALESCE(preg_status.is_currently_pregnant, FALSE) = TRUE AND COALESCE(ld.is_on_register, FALSE) = TRUE THEN 'Pregnancy, Learning Disability'
+        WHEN COALESCE(preg_status.is_currently_pregnant, FALSE) = TRUE THEN 'Pregnancy'
+        WHEN COALESCE(ld.is_on_register, FALSE) = TRUE THEN 'Learning Disability'
+        ELSE ''
+    END AS additional_findings,
+    
+    -- Condition group logic
+    CASE
+        WHEN COALESCE(neu.has_neurology_event, FALSE) = FALSE AND COALESCE(psych.has_psych_event, FALSE) = FALSE THEN ''
+        WHEN COALESCE(neu.has_neurology_event, FALSE) = TRUE AND COALESCE(psych.has_psych_event, FALSE) = TRUE THEN 'Neurology, Psychiatry'
+        WHEN COALESCE(neu.has_neurology_event, FALSE) = TRUE THEN 'Neurology'
+        WHEN COALESCE(psych.has_psych_event, FALSE) = TRUE THEN 'Psychiatry'
+        ELSE ''
+    END AS condition_group,
+    
+    CURRENT_DATE() AS calculation_date
+    
 FROM db_scope AS db
 LEFT JOIN ppp_status AS ppp ON db.person_id = ppp.person_id
 LEFT JOIN araf AS araf ON db.person_id = araf.person_id
 LEFT JOIN araf_referral AS arref ON db.person_id = arref.person_id
 LEFT JOIN neurology AS neu ON db.person_id = neu.person_id
 LEFT JOIN psychiatry AS psych ON db.person_id = psych.person_id
-LEFT JOIN preg ON db.person_id = preg.person_id
--- Brief: Implements clinical action logic for Valproate safety monitoring, using all dependency marts. Adjust logic as needed for full business rules.
+LEFT JOIN pregnancy_status AS preg_status ON db.person_id = preg_status.person_id
+LEFT JOIN learning_disability AS ld ON db.person_id = ld.person_id

--- a/models/marts/programme/valproate/dim_valproate_action_status.yml
+++ b/models/marts/programme/valproate/dim_valproate_action_status.yml
@@ -1,49 +1,73 @@
 version: 2
 models:
 - name: dim_valproate_action_status
-  description: 'Clinical decision support table implementing valproate safety monitoring logic with recommended actions.
+  description: 'Dimension table implementing Valproate safety monitoring clinical decision logic.
 
 
-    Business Logic:
+    Calculates recommended actions and priority order (1-9) based on:
 
-    • Joins database scope with all dimension tables (PPP, ARAF, referrals, specialists, pregnancy)
+    • Pregnancy status
 
-    • Implements CASE-based decision logic for recommended actions based on patient status
+    • PPP enrollment  
 
-    • Actions include: pregnancy review, PPP enrollment check, ARAF compliance, specialist monitoring
+    • ARAF completion
 
-    • Provides consolidated view of all patient safety monitoring dimensions for decision support'
+    • Age and risk factors
+
+
+    Action priorities:
+
+    • 1 = Pregnancy (urgent)
+
+    • 2-4 = Missing safety measures by age/vulnerability
+
+    • 5 = PPP non-enrolled (monitor)
+
+    • 6-8 = Safety measures present (check ARAF expiry)
+
+    • 9 = Low risk (no action)'
 
   columns:
   - name: person_id
     description: Unique identifier for the person.
-
     tests:
     - not_null
     - unique
   - name: age
-    description: Patient's age.
+    description: Age of the person at time of calculation.
   - name: sex
     description: Patient's sex.
-  - name: is_woman_of_child_bearing_age
-    description: TRUE if the person is a woman of child-bearing age.
-  - name: has_recent_valproate_medication
-    description: TRUE if the person has a recent valproate prescription.
-  - name: has_ppp_event
-    description: TRUE if any PPP event is present for the person.
-  - name: is_currently_ppp_enrolled
-    description: TRUE if most recent PPP status indicates enrollment.
-  - name: current_ppp_status_description
-    description: Human-readable description of current PPP status.
+  - name: has_ppp_status
+    description: TRUE if person has any PPP record in the system.
+  - name: is_ppp_enrolled
+    description: TRUE if enrolled in PPP, FALSE otherwise.
+  - name: is_ppp_non_enrolled
+    description: TRUE if PPP status is discontinued/not needed/declined.
+  - name: ppp_status_description
+    description: Description of PPP status.
   - name: has_araf_event
-    description: TRUE if any ARAF event is present for the person.
-  - name: has_specific_araf_form_meeting_lookback
-    description: TRUE if an ARAF form event meeting lookback criteria is recorded.
-  - name: has_araf_referral_event
-    description: TRUE if any ARAF referral event is present for the person.
-  - name: has_neurology_event
-    description: TRUE if any neurology event is present for the person.
-  - name: has_psych_event
-    description: TRUE if any psychiatry event is present for the person.
-  - name: recommended_action
-    description: Recommended clinical action for the person based on safety logic.
+    description: TRUE if person has any ARAF record in the system.
+  - name: has_current_araf
+    description: TRUE if person has ARAF meeting lookback requirements.
+  - name: has_permanent_absence_pregnancy_risk
+    description: TRUE if permanent absence of pregnancy risk recorded.
+  - name: has_learning_disability
+    description: TRUE if learning disability recorded.
+  - name: has_pregnancy
+    description: TRUE if currently pregnant.
+  - name: has_neurology
+    description: TRUE if person has neurology-related conditions.
+  - name: has_psychiatry
+    description: TRUE if person has psychiatry-related conditions.
+  - name: risk_of_pregnancy
+    description: 'Risk category: Low Risk, Medium Risk, High Risk.'
+  - name: action
+    description: Recommended action based on business rules.
+  - name: action_order
+    description: Numeric priority order for action (1=highest priority).
+  - name: additional_findings
+    description: Summary of pregnancy and learning disability findings.
+  - name: condition_group
+    description: Summary of neurology and psychiatry condition groups.
+  - name: calculation_date
+    description: Date when this calculation was performed.

--- a/models/marts/programme/valproate/dim_valproate_araf.sql
+++ b/models/marts/programme/valproate/dim_valproate_araf.sql
@@ -32,6 +32,24 @@ SELECT
     pla.all_araf_concept_displays,
     pla.all_araf_code_categories_applied,
     coalesce(pla.has_specific_araf_form_meeting_lookback, FALSE)
-        AS has_specific_araf_form_meeting_lookback
+        AS has_specific_araf_form_meeting_lookback,
+    
+    -- ARAF form type flags
+    array_contains('1366401000000107'::VARIANT, pla.all_araf_concept_codes) AS has_old_annual_risk_acknowledgement_form,
+    array_contains('2078951000000106'::VARIANT, pla.all_araf_concept_codes) AS has_new_annual_risk_acknowledgement_form,
+    
+    -- ARAF form type info with dates
+    CASE 
+        WHEN array_contains('1366401000000107'::VARIANT, pla.all_araf_concept_codes) 
+        THEN 'Yes (' || TO_VARCHAR(pla.latest_specific_araf_form_date, 'DD/MM/YYYY') || ')' 
+        ELSE 'No' 
+    END AS old_annual_risk_acknowledgement_form_info,
+    
+    CASE 
+        WHEN array_contains('2078951000000106'::VARIANT, pla.all_araf_concept_codes) 
+        THEN 'Yes (' || TO_VARCHAR(pla.latest_specific_araf_form_date, 'DD/MM/YYYY') || ')' 
+        ELSE 'No' 
+    END AS new_annual_risk_acknowledgement_form_info
+    
 FROM person_level_araf_aggregation AS pla
 -- Brief: Aggregates ARAF events and status for valproate cohort, using intermediate ARAF events table. Includes latest and historical ARAF status, event details, and code traceability.

--- a/models/marts/programme/valproate/dim_valproate_araf.yml
+++ b/models/marts/programme/valproate/dim_valproate_araf.yml
@@ -14,7 +14,11 @@ models:
 
     • Includes arrays of all observation IDs, concept codes, and displays for traceability
 
-    • Only includes people who have ARAF events (has_araf_event always TRUE)'
+    • Only includes people who have ARAF events (has_araf_event always TRUE)
+
+    • Includes flags for old and new annual risk acknowledgement form types
+
+    • Provides form type information with dates for traceability'
 
   columns:
   - name: person_id
@@ -47,3 +51,11 @@ models:
     description: Array of display terms for the ARAF codes.
   - name: all_araf_code_categories_applied
     description: Array of code categories applied (should contain only 'ARAF').
+  - name: has_old_annual_risk_acknowledgement_form
+    description: TRUE if person has old annual risk acknowledgement form (concept code 1366401000000107).
+  - name: has_new_annual_risk_acknowledgement_form
+    description: TRUE if person has new annual risk acknowledgement form (concept code 2078951000000106).
+  - name: old_annual_risk_acknowledgement_form_info
+    description: Information about old annual risk acknowledgement form with date if present.
+  - name: new_annual_risk_acknowledgement_form_info
+    description: Information about new annual risk acknowledgement form with date if present.


### PR DESCRIPTION
## Summary
- Add action_order field (1-9 priority ranking) to dim_valproate_action_status with comprehensive business logic matching legacy model
- Add ARAF form type flags to dim_valproate_araf for distinguishing old/new annual risk acknowledgement forms
- Update YAML descriptions to reflect new fields and accurate business logic
- Fix field name reference from is_on_ld_register to is_on_register

## Changes Made
### dim_valproate_action_status
- Added action_order field with 1-9 priority ranking system
- Added comprehensive business logic for pregnancy, PPP, ARAF status assessment
- Added learning disability and permanent absence pregnancy risk flags
- Added risk classification and additional findings groupings
- Updated YAML metadata to reflect new fields

### dim_valproate_araf
- Added has_old_annual_risk_acknowledgement_form flag (concept code 1366401000000107)
- Added has_new_annual_risk_acknowledgement_form flag (concept code 2078951000000106)
- Added form type information fields with dates for traceability
- Updated YAML metadata to document new fields

## Test Plan
- [x] Models compile successfully
- [x] Models run without errors in development environment
- [x] Business logic matches legacy model behaviour
- [x] New fields are properly documented in YAML

## Related Issue
Closes #89