### PR TITLE
feat: add dim_person_conditions table for wide format condition flags

### DIFF
--- a/models/marts/disease_registers/dim_person_conditions.sql
+++ b/models/marts/disease_registers/dim_person_conditions.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+-- Person Conditions Dimension
+-- Wide format pivot of fct_person_ltc_summary providing boolean flags for each condition
+-- One row per person with condition presence flags for easier analytical consumption
+
+SELECT
+    person_id,
+    
+    -- Boolean condition flags (pivoted from condition_code)
+    MAX(CASE WHEN condition_code = 'AF' THEN TRUE ELSE FALSE END) AS has_atrial_fibrillation,
+    MAX(CASE WHEN condition_code = 'AST' THEN TRUE ELSE FALSE END) AS has_asthma,
+    MAX(CASE WHEN condition_code = 'CAN' THEN TRUE ELSE FALSE END) AS has_cancer,
+    MAX(CASE WHEN condition_code = 'CHD' THEN TRUE ELSE FALSE END) AS has_coronary_heart_disease,
+    MAX(CASE WHEN condition_code = 'CKD' THEN TRUE ELSE FALSE END) AS has_chronic_kidney_disease,
+    MAX(CASE WHEN condition_code = 'COPD' THEN TRUE ELSE FALSE END) AS has_copd,
+    MAX(CASE WHEN condition_code = 'CYP_AST' THEN TRUE ELSE FALSE END) AS has_cyp_asthma,
+    MAX(CASE WHEN condition_code = 'DEM' THEN TRUE ELSE FALSE END) AS has_dementia,
+    MAX(CASE WHEN condition_code = 'DEP' THEN TRUE ELSE FALSE END) AS has_depression,
+    MAX(CASE WHEN condition_code = 'DM' THEN TRUE ELSE FALSE END) AS has_diabetes,
+    MAX(CASE WHEN condition_code = 'EP' THEN TRUE ELSE FALSE END) AS has_epilepsy,
+    MAX(CASE WHEN condition_code = 'FH' THEN TRUE ELSE FALSE END) AS has_familial_hypercholesterolaemia,
+    MAX(CASE WHEN condition_code = 'GESTDIAB' THEN TRUE ELSE FALSE END) AS has_gestational_diabetes,
+    MAX(CASE WHEN condition_code = 'HF' THEN TRUE ELSE FALSE END) AS has_heart_failure,
+    MAX(CASE WHEN condition_code = 'HTN' THEN TRUE ELSE FALSE END) AS has_hypertension,
+    MAX(CASE WHEN condition_code = 'LD' THEN TRUE ELSE FALSE END) AS has_learning_disability,
+    MAX(CASE WHEN condition_code = 'NAFLD' THEN TRUE ELSE FALSE END) AS has_nafld,
+    MAX(CASE WHEN condition_code = 'NDH' THEN TRUE ELSE FALSE END) AS has_non_diabetic_hyperglycaemia,
+    MAX(CASE WHEN condition_code = 'OB' THEN TRUE ELSE FALSE END) AS has_obesity,
+    MAX(CASE WHEN condition_code = 'OST' THEN TRUE ELSE FALSE END) AS has_osteoporosis,
+    MAX(CASE WHEN condition_code = 'PAD' THEN TRUE ELSE FALSE END) AS has_peripheral_arterial_disease,
+    MAX(CASE WHEN condition_code = 'PC' THEN TRUE ELSE FALSE END) AS has_palliative_care,
+    MAX(CASE WHEN condition_code = 'RA' THEN TRUE ELSE FALSE END) AS has_rheumatoid_arthritis,
+    MAX(CASE WHEN condition_code = 'SMI' THEN TRUE ELSE FALSE END) AS has_severe_mental_illness,
+    MAX(CASE WHEN condition_code = 'STIA' THEN TRUE ELSE FALSE END) AS has_stroke_tia,
+    
+    -- Summary counts
+    COUNT(DISTINCT condition_code) AS total_conditions,
+    COUNT(DISTINCT CASE WHEN is_qof = TRUE THEN condition_code END) AS total_qof_conditions,
+    COUNT(DISTINCT CASE WHEN is_qof = FALSE THEN condition_code END) AS total_non_qof_conditions,
+    
+    -- Clinical domain counts
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Cardiovascular' THEN condition_code END) AS cardiovascular_conditions,
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Respiratory' THEN condition_code END) AS respiratory_conditions,
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Mental Health' THEN condition_code END) AS mental_health_conditions,
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Metabolic' THEN condition_code END) AS metabolic_conditions,
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Musculoskeletal' THEN condition_code END) AS musculoskeletal_conditions,
+    COUNT(DISTINCT CASE WHEN clinical_domain = 'Neurology' THEN condition_code END) AS neurology_conditions,
+    
+    -- Earliest and latest diagnosis dates across all conditions
+    MIN(earliest_diagnosis_date) AS earliest_condition_diagnosis,
+    MAX(latest_diagnosis_date) AS latest_condition_diagnosis
+
+FROM {{ ref('fct_person_ltc_summary') }}
+GROUP BY person_id

--- a/models/marts/disease_registers/dim_person_conditions.yml
+++ b/models/marts/disease_registers/dim_person_conditions.yml
@@ -1,0 +1,245 @@
+version: 2
+models:
+- name: dim_person_conditions
+  description: 'Person Conditions Dimension - Wide format pivot of LTC summary providing boolean flags for each condition per person.
+
+
+    Key Features:
+
+    • One row per person with condition presence flags
+
+    • Boolean columns for each condition (has_diabetes, has_hypertension, etc.)
+
+    • Summary counts for total conditions and QOF conditions
+
+    • Clinical domain counts (cardiovascular, respiratory, etc.)
+
+    • Earliest and latest diagnosis dates across all conditions
+
+
+    Purpose: Simplified analytical table for condition profiling, multi-morbidity analysis, and dashboard consumption. Provides easy boolean lookup for condition presence.'
+
+  columns:
+  - name: person_id
+    description: Unique person identifier
+
+    tests:
+    - not_null
+    - unique
+
+  - name: has_atrial_fibrillation
+    description: Boolean flag indicating if person has Atrial Fibrillation (AF)
+
+    tests:
+    - not_null
+  - name: has_asthma
+    description: Boolean flag indicating if person has Asthma (AST)
+
+    tests:
+    - not_null
+  - name: has_cancer
+    description: Boolean flag indicating if person has Cancer (CAN)
+
+    tests:
+    - not_null
+  - name: has_coronary_heart_disease
+    description: Boolean flag indicating if person has Coronary Heart Disease (CHD)
+
+    tests:
+    - not_null
+  - name: has_chronic_kidney_disease
+    description: Boolean flag indicating if person has Chronic Kidney Disease (CKD)
+
+    tests:
+    - not_null
+  - name: has_copd
+    description: Boolean flag indicating if person has Chronic Obstructive Pulmonary Disease (COPD)
+
+    tests:
+    - not_null
+  - name: has_cyp_asthma
+    description: Boolean flag indicating if person has Children and Young People Asthma (CYP_AST)
+
+    tests:
+    - not_null
+  - name: has_dementia
+    description: Boolean flag indicating if person has Dementia (DEM)
+
+    tests:
+    - not_null
+  - name: has_depression
+    description: Boolean flag indicating if person has Depression (DEP)
+
+    tests:
+    - not_null
+  - name: has_diabetes
+    description: Boolean flag indicating if person has Diabetes Mellitus (DM)
+
+    tests:
+    - not_null
+  - name: has_epilepsy
+    description: Boolean flag indicating if person has Epilepsy (EP)
+
+    tests:
+    - not_null
+  - name: has_familial_hypercholesterolaemia
+    description: Boolean flag indicating if person has Familial Hypercholesterolaemia (FH)
+
+    tests:
+    - not_null
+  - name: has_gestational_diabetes
+    description: Boolean flag indicating if person has Gestational Diabetes (GESTDIAB)
+
+    tests:
+    - not_null
+  - name: has_heart_failure
+    description: Boolean flag indicating if person has Heart Failure (HF)
+
+    tests:
+    - not_null
+  - name: has_hypertension
+    description: Boolean flag indicating if person has Hypertension (HTN)
+
+    tests:
+    - not_null
+  - name: has_learning_disability
+    description: Boolean flag indicating if person has Learning Disability (LD)
+
+    tests:
+    - not_null
+  - name: has_nafld
+    description: Boolean flag indicating if person has Non-Alcoholic Fatty Liver Disease (NAFLD)
+
+    tests:
+    - not_null
+  - name: has_non_diabetic_hyperglycaemia
+    description: Boolean flag indicating if person has Non-Diabetic Hyperglycaemia (NDH)
+
+    tests:
+    - not_null
+  - name: has_obesity
+    description: Boolean flag indicating if person has Obesity (OB)
+
+    tests:
+    - not_null
+  - name: has_osteoporosis
+    description: Boolean flag indicating if person has Osteoporosis (OST)
+
+    tests:
+    - not_null
+  - name: has_peripheral_arterial_disease
+    description: Boolean flag indicating if person has Peripheral Arterial Disease (PAD)
+
+    tests:
+    - not_null
+  - name: has_palliative_care
+    description: Boolean flag indicating if person has Palliative Care (PC)
+
+    tests:
+    - not_null
+  - name: has_rheumatoid_arthritis
+    description: Boolean flag indicating if person has Rheumatoid Arthritis (RA)
+
+    tests:
+    - not_null
+  - name: has_severe_mental_illness
+    description: Boolean flag indicating if person has Severe Mental Illness (SMI)
+
+    tests:
+    - not_null
+  - name: has_stroke_tia
+    description: Boolean flag indicating if person has Stroke and TIA (STIA)
+
+    tests:
+    - not_null
+  - name: total_conditions
+    description: Total number of distinct conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 1
+        max_value: 25
+  - name: total_qof_conditions
+    description: Total number of QOF conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 25
+  - name: total_non_qof_conditions
+    description: Total number of non-QOF conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 25
+  - name: cardiovascular_conditions
+    description: Number of cardiovascular conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: respiratory_conditions
+    description: Number of respiratory conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: mental_health_conditions
+    description: Number of mental health conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: metabolic_conditions
+    description: Number of metabolic conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: musculoskeletal_conditions
+    description: Number of musculoskeletal conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: neurology_conditions
+    description: Number of neurology conditions this person has
+
+    tests:
+    - not_null
+    - dbt_utils.accepted_range:
+
+        min_value: 0
+        max_value: 10
+  - name: earliest_condition_diagnosis
+    description: Earliest diagnosis date across all conditions for this person
+
+    tests:
+    - not_null
+  - name: latest_condition_diagnosis
+    description: Latest diagnosis date across all conditions for this person
+
+    tests:
+    - not_null


### PR DESCRIPTION
## Summary
• Implements `dim_person_conditions` table that pivots `fct_person_ltc_summary` into wide format with boolean condition flags
• Provides one row per person with easy-to-use boolean columns for each condition
• Includes comprehensive YAML schema with full documentation and test coverage

## Key Features
• 25 boolean condition flags (has_diabetes, has_hypertension, etc.)
• Summary counts for total conditions and QOF conditions  
• Clinical domain counts (cardiovascular, respiratory, mental health, etc.)
• Earliest and latest diagnosis dates across all conditions
• Clustered on person_id for optimal performance
• Full test coverage including range validations

## Files Changed
• `models/marts/disease_registers/dim_person_conditions.sql` - Main model implementation
• `models/marts/disease_registers/dim_person_conditions.yml` - Schema documentation and tests

## Test Plan
- [x] Model runs successfully without errors
- [x] YAML schema validates correctly
- [x] All 25 condition codes from fct_person_ltc_summary are represented
- [x] Boolean flags work correctly for condition presence
- [x] Summary counts calculate properly
- [x] Clinical domain counts aggregate correctly
- [x] Clustering improves query performance on person_id

Closes #91