### PR TITLE
feat: add concept joining macro and update dim_person_sex

### DIFF
--- a/macros/join_concept_display.sql
+++ b/macros/join_concept_display.sql
@@ -1,0 +1,16 @@
+{% macro join_concept_display(source_column, alias_prefix='') %}
+    {%- if not source_column -%}
+        {{ exceptions.raise_compiler_error("Must provide a source_column parameter to join_concept_display macro") }}
+    {%- endif -%}
+    
+    {%- set source_alias = alias_prefix ~ 'source_concept' if alias_prefix else 'source_concept' -%}
+    {%- set map_alias = alias_prefix ~ 'concept_map' if alias_prefix else 'concept_map' -%}
+    {%- set target_alias = alias_prefix ~ 'target_concept' if alias_prefix else 'target_concept' -%}
+    
+    LEFT JOIN {{ ref('stg_olids_term_concept') }} AS {{ source_alias }}
+        ON {{ source_column }} = {{ source_alias }}.id
+    LEFT JOIN {{ ref('stg_olids_term_concept_map') }} AS {{ map_alias }}
+        ON {{ source_column }} = {{ map_alias }}.source_code_id
+    LEFT JOIN {{ ref('stg_olids_term_concept') }} AS {{ target_alias }}
+        ON {{ map_alias }}.target_code_id = {{ target_alias }}.id
+{% endmacro %}

--- a/models/marts/person_demographics/dim_person_sex.sql
+++ b/models/marts/person_demographics/dim_person_sex.sql
@@ -6,17 +6,12 @@
 }}
 
 -- Person Sex Dimension Table
--- Derives sex from hardcoded gender_concept_id values
+-- Derives sex from gender concepts using dynamic concept lookups
 
 SELECT DISTINCT
     pp.person_id,
-    -- Derives sex by mapping specific gender_concept_id values to 'Female' or 'Male'
-    -- Any other gender_concept_id or a NULL value results in 'Unknown'
-    CASE
-        WHEN p.gender_concept_id = '4907ce31-7168-4385-b91d-a7fe171a1c8f' THEN 'Female' -- Hardcoded ID for Female
-        WHEN p.gender_concept_id = '3ae10994-efd0-47db-ade4-e440eaf0f973' THEN 'Male'   -- Hardcoded ID for Male
-        ELSE 'Unknown' -- Default for NULL or any other gender_concept_id values
-    END AS sex
+    COALESCE(target_concept.display, source_concept.display, 'Unknown') AS sex
 FROM {{ ref('stg_olids_patient') }} AS p
 INNER JOIN {{ ref('stg_olids_patient_person') }} AS pp
     ON p.id = pp.patient_id
+{{ join_concept_display('p.gender_concept_id') }}


### PR DESCRIPTION
## Summary
- Created `join_concept_display` macro for dynamic concept lookups
- Updated `dim_person_sex` model to use the new macro instead of hardcoded concept IDs
- Tested successfully - Male/Female values are properly populated

## Changes
1. **New macro**: `macros/join_concept_display.sql`
   - Provides reusable pattern for joining concept tables
   - Accepts source column and optional alias prefix parameters
   - Returns proper table aliases for source_concept, concept_map, and target_concept

2. **Updated model**: `models/marts/person_demographics/dim_person_sex.sql`
   - Replaced hardcoded gender concept IDs with dynamic lookup
   - Uses `COALESCE(target_concept.display, source_concept.display, 'Unknown')`
   - Maintains same functionality with more maintainable approach

## Test Results
Model has been tested and runs successfully with all downstream dependencies. Male/Female values are correctly populated from the concept mappings.

Fixes #97