### PR TITLE
feat: add SQLFluff auto-formatting to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,12 @@ repos:
     hooks:
       - id: sqlfluff-fix-local
         name: SQLFluff Fix (Auto-format SQL)
-        entry: bash -c 'source venv/Scripts/activate && python -m sqlfluff fix "$@" || true'
+        entry: bash -c 'for file in "$@"; do if [[ "$file" =~ ^(models|macros|tests|analyses)/.*\.sql$ ]]; then source venv/Scripts/activate && python -m sqlfluff fix "$file" --force --disable-progress-bar || true; fi; done'
         language: system
-        files: '^(models|macros|tests|analyses)/.*\.sql$'
+        types: [sql]
         pass_filenames: true
+        require_serial: true
+        verbose: false
 
   # Basic code quality checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         name: SQLFluff Fix (Auto-format SQL)
         entry: bash -c 'source venv/Scripts/activate && python -m sqlfluff fix "$@" || true'
         language: system
-        files: '\.sql$'
+        files: '^(models|macros|tests|analyses)/.*\.sql$'
         pass_filenames: true
 
   # Basic code quality checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,16 @@ repos:
         stages: [commit-msg]
         args: [feat, fix, docs, refactor, test, chore]
 
+  # SQL formatting with SQLFluff (never blocks commits)
+  - repo: local
+    hooks:
+      - id: sqlfluff-fix-local
+        name: SQLFluff Fix (Auto-format SQL)
+        entry: bash -c 'source venv/Scripts/activate && python -m sqlfluff fix "$@" || true'
+        language: system
+        files: '\.sql$'
+        pass_filenames: true
+
   # Basic code quality checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
## Summary
• Added SQLFluff to precommit hooks for automatic SQL formatting
• Configured to run silently without blocking commits
• Only formats staged SQL files in active development directories
• Provides lightweight, behind-the-scenes formatting improvements

## Changes Made
• Added SQLFluff configuration to `.pre-commit-config.yaml`
• Restricted formatting to `models/`, `macros/`, `tests/`, and `analyses/` directories
• Used local hook with bash script to ensure it never blocks commits
• Disabled progress bar for cleaner output

## Benefits
• Automatic SQL formatting on commit
• No manual formatting required
• Consistent code style across the codebase
• Fast execution - only processes staged files
• Never blocks commits even if formatting fails

## Test Plan
- [ ] Commit a SQL file with poor formatting in models/ directory
- [ ] Verify SQLFluff automatically formats it
- [ ] Commit a file in legacy/ directory
- [ ] Verify SQLFluff ignores it
- [ ] Test with intentionally broken SQL
- [ ] Verify commit still succeeds