### PR TITLE
fix: update stg_olids_person to use PERSON_BACKUP source table

### DIFF
--- a/models/staging/stg_olids_person.sql
+++ b/models/staging/stg_olids_person.sql
@@ -1,5 +1,6 @@
--- Staging model for OLIDS_MASKED.PERSON
+-- Staging model for OLIDS_MASKED.PERSON_BACKUP
 -- Source: "Data_Store_OLIDS_UAT".OLIDS_MASKED
+-- Using PERSON_BACKUP as PERSON table was deleted
 
 SELECT
     "lds_id" AS lds_id,
@@ -16,4 +17,4 @@ SELECT
     "requesting_patient_id" AS requesting_patient_id,
     "lds_start_date_time" AS lds_start_date_time,
     "lds_end_date_time" AS lds_end_date_time
-FROM {{ source('OLIDS_MASKED', 'PERSON') }}
+FROM {{ source('OLIDS_MASKED', 'PERSON_BACKUP') }}


### PR DESCRIPTION
## Summary
Updates the `stg_olids_person` staging model to use the correct source table after the PERSON table was deleted from the source system.

## Issue
- The original PERSON table was deleted from the source system
- `stg_olids_person` was referencing the non-existent PERSON table
- This caused compilation errors in models that depend on person data
- PERSON_BACKUP contains the same schema and data as the original PERSON table

## Changes
- **Source table**: Changed from `PERSON` to `PERSON_BACKUP`
- **Column references**: Kept all existing column mappings (they exist in PERSON_BACKUP)
- **Comments**: Updated to clarify use of backup table

## Impact
- ✅ Resolves compilation errors in downstream models
- ✅ Maintains compatibility with existing person-based dimensions
- ✅ No breaking changes to column structure or data types
- ✅ All column references verified against PERSON_BACKUP schema

## Validation
- Confirmed PERSON_BACKUP contains all required columns
- Verified column data types match expectations
- All pre-commit hooks passing

This is a straightforward source table update with no functional changes to the staging logic.