### PR TITLE
Remove QA target from profiles.yml template

### DIFF
--- a/profiles.yml.template
+++ b/profiles.yml.template
@@ -9,7 +9,7 @@
 # sensitive connection information.
 
 snowflake_hei_migration:
-  target: dev  # Default target - use wrapper scripts or --target for other environments
+  target: dev  # Default target - use --target prod for production environment
   outputs:
     dev:
       type: snowflake
@@ -24,18 +24,6 @@ snowflake_hei_migration:
       client_session_keep_alive: true
       query_tag: "dbt_hei_migration_dev"
 
-    qa:
-      type: snowflake
-      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
-      user: "{{ env_var('SNOWFLAKE_USER') }}"
-      authenticator: externalbrowser
-      role: "{{ env_var('SNOWFLAKE_ROLE') }}"
-      database: DATA_LAB_OLIDS_UAT
-      schema: DBT_QA  # qa schema
-      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
-      threads: 6
-      client_session_keep_alive: true
-      query_tag: "dbt_hei_migration_qa"
 
     prod:
       type: snowflake


### PR DESCRIPTION
## Summary

• Removed unused QA target configuration from profiles.yml template
• Updated comment to reflect only dev and prod environments

## Changes

- Removed the entire `qa:` target section from the template
- Updated the default target comment to mention `--target prod` instead of referencing wrapper scripts

## Context

The QA target is no longer used in the project workflow, so removing it simplifies the configuration and prevents confusion.