### PR TITLE
Fix numeric overflow errors in creatinine and HbA1c models

### DIFF
--- a/models/intermediate/observations/int_creatinine_all.sql
+++ b/models/intermediate/observations/int_creatinine_all.sql
@@ -15,7 +15,7 @@ WITH base_observations AS (
         obs.observation_id,
         obs.person_id,
         obs.clinical_effective_date,
-        CAST(obs.result_value AS NUMBER(6,1)) AS creatinine_value,
+        CAST(obs.result_value AS NUMBER(10,1)) AS creatinine_value,
         obs.result_unit_display,
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,

--- a/models/intermediate/observations/int_hba1c_all.sql
+++ b/models/intermediate/observations/int_hba1c_all.sql
@@ -16,7 +16,7 @@ WITH base_observations AS (
         obs.observation_id,
         obs.person_id,
         obs.clinical_effective_date,
-        CAST(obs.result_value AS NUMBER(6,2)) AS hba1c_value,
+        CAST(obs.result_value AS NUMBER(10,2)) AS hba1c_value,
         obs.result_unit_display,
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,


### PR DESCRIPTION
## Summary

• Increased numeric precision in int_creatinine_all and int_hba1c_all models to handle extreme outlier values
• Prevents numeric overflow errors that were causing model failures

## Changes

- **int_creatinine_all**: Changed from NUMBER(6,1) to NUMBER(10,1)
  - Previous limit: 99999.9
  - New limit: 999999999.9
  - Error value: 120000

- **int_hba1c_all**: Changed from NUMBER(6,2) to NUMBER(10,2)
  - Previous limit: 9999.99
  - New limit: 99999999.99
  - Error value: 40000

## Testing

Successfully ran both models and their downstream dependencies:
- int_creatinine_all → int_creatinine_latest
- int_hba1c_all → int_hba1c_latest, dq_hba1c_issues, fct_person_diabetes_8_care_processes, fct_person_diabetes_triple_target, fct_person_diabetes_9_care_processes

## Impact

- No impact on data quality or clinical logic
- Existing validation logic still flags these extreme values as invalid
- Models can now process data without failing on outliers

Fixes #118, Fixes #119