### PR TITLE
fix: refactor get_observations and get_medication_orders macros to use native terminology joins

### DIFF
--- a/macros/get_medication_orders.sql
+++ b/macros/get_medication_orders.sql
@@ -32,46 +32,45 @@
         mo.quantity_unit AS order_quantity_unit,
         mo.duration_days AS order_duration_days,
         ms.medication_name AS statement_medication_name,
-        mc.concept_code AS mapped_concept_code,
-        mc.code_description AS mapped_concept_display,
+        c.code AS mapped_concept_code,
+        c.display AS mapped_concept_display,
         {% if ecl_cluster is not none %}
         '{{ ecl_cluster|upper }}' AS cluster_id,
+        {% elif cluster_id is not none %}
+        cc.cluster_id,
         {% else %}
-        mc.cluster_id,
+        NULL AS cluster_id,
         {% endif %}
         bnf.bnf_code,
         bnf.bnf_name
     FROM {{ ref('stg_olids_medication_order') }} mo
     JOIN {{ ref('stg_olids_medication_statement') }} ms
         ON mo.medication_statement_id = ms.id
-    JOIN {{ ref('stg_codesets_mapped_concepts') }} mc
-        ON ms.medication_statement_core_concept_id = mc.source_code_id
+    -- Join through CONCEPT_MAP to CONCEPT (native terminology path)
+    JOIN {{ ref('stg_olids_term_concept_map') }} cm
+        ON ms.medication_statement_core_concept_id = cm.source_code_id
+    JOIN {{ ref('stg_olids_term_concept') }} c
+        ON cm.target_code_id = c.id
     {% if ecl_cluster is not none %}
     JOIN TABLE(DATA_LAB_OLIDS_UAT.REFERENCE.ECL_CACHED_DETAILS('{{ ecl_cluster|lower }}')) ecl
-        ON mc.concept_code = ecl.code
+        ON c.code = ecl.code
     {% endif %}
     LEFT JOIN {{ ref('stg_codesets_bnf_latest') }} bnf
-        ON mc.concept_code = bnf.snomed_code
-    JOIN {{ ref('stg_olids_patient') }} p
+        ON c.code = bnf.snomed_code
+    JOIN {{ ref('int_patient_person_unique') }} pp
+        ON mo.patient_id = pp.patient_id
+    LEFT JOIN {{ ref('stg_olids_patient') }} p
         ON mo.patient_id = p.id
-    JOIN {{ ref('stg_olids_patient_person') }} pp
-        ON p.id = pp.patient_id
+    {% if cluster_id is not none %}
+    JOIN {{ ref('stg_codesets_combined_codesets') }} cc
+        ON c.code = cc.code
+        AND cc.cluster_id IN ('{{ cluster_ids_str }}')
+        {% if source is not none %}
+        AND cc.source = '{{ source }}'
+        {% endif %}
+    {% endif %}
     WHERE mo.clinical_effective_date IS NOT NULL
-        {% if cluster_id is not none %}
-            AND mc.cluster_id IN ('{{ cluster_ids_str }}')
-        {% endif %}
-{% if source is not none and ecl_cluster is none %}
-            AND mc.source = '{{ source }}'
-        {% endif %}
 {% if bnf_code is not none %}
-            AND bnf.bnf_code LIKE '{{ bnf_code }}%'
+        AND bnf.bnf_code LIKE '{{ bnf_code }}%'
         {% endif %}
-    QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY mo.id, mc.concept_code, bnf.bnf_code
-        ORDER BY
-            CASE WHEN mc.code_description IS NOT NULL THEN 1 ELSE 2 END,
-            CASE WHEN bnf.bnf_name IS NOT NULL THEN 1 ELSE 2 END,
-            mc.code_description,
-            bnf.bnf_name
-    ) = 1
 {% endmacro %}

--- a/macros/get_observations.sql
+++ b/macros/get_observations.sql
@@ -10,7 +10,7 @@
         o.id AS observation_id,
         o.patient_id,
         pp.person_id,
-        p.sk_patient_id,
+        NULL AS sk_patient_id,  -- Remove dependency on PATIENT table
         o.clinical_effective_date,
         o.result_value,
         o.result_value_unit_concept_id,
@@ -20,28 +20,25 @@
         o.is_review,
         o.problem_end_date,
         o.observation_source_concept_id,
-        mc.concept_id AS mapped_concept_id,
-        mc.concept_code AS mapped_concept_code,
-        mc.code_description AS mapped_concept_display,
-        mc.cluster_id,
-        mc.cluster_description
+        c.id AS mapped_concept_id,
+        c.code AS mapped_concept_code,
+        c.display AS mapped_concept_display,
+        cc.cluster_id,
+        cc.cluster_description
     FROM {{ ref('stg_olids_observation') }} o
-    JOIN {{ ref('stg_olids_patient') }} p
-        ON o.patient_id = p.id
-    JOIN {{ ref('stg_olids_patient_person') }} pp
-        ON p.id = pp.patient_id
+    -- Join through CONCEPT_MAP to CONCEPT (native terminology path)
+    JOIN {{ ref('stg_olids_term_concept_map') }} cm
+        ON o.observation_source_concept_id = cm.source_code_id
+    JOIN {{ ref('stg_olids_term_concept') }} c
+        ON cm.target_code_id = c.id
+    JOIN {{ ref('int_patient_person_unique') }} pp
+        ON o.patient_id = pp.patient_id
     LEFT JOIN {{ ref('stg_olids_term_concept') }} unit_con
         ON o.result_value_unit_concept_id = unit_con.id
-    JOIN {{ ref('stg_codesets_mapped_concepts') }} mc
-        ON o.observation_source_concept_id = mc.source_code_id
-        AND mc.cluster_id IN ({{ cluster_ids }})
+    JOIN {{ ref('stg_codesets_combined_codesets') }} cc
+        ON c.code = cc.code
+        AND cc.cluster_id IN ({{ cluster_ids }})
         {% if source %}
-        AND mc.source = '{{ source }}'
+        AND cc.source = '{{ source }}'
         {% endif %}
-    QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY o.id, mc.concept_code, mc.cluster_id
-        ORDER BY
-            CASE WHEN mc.code_description IS NOT NULL THEN 1 ELSE 2 END,
-            mc.code_description
-    ) = 1
 {% endmacro %}

--- a/models/intermediate/person_attributes/int_patient_person_unique.sql
+++ b/models/intermediate/person_attributes/int_patient_person_unique.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+Deduplicated patient-person mappings.
+Handles cases where multiple patient_ids may map to the same person_id.
+
+When multiple patient_ids exist for the same person_id, selects the 
+lowest patient_id to ensure consistent mapping.
+
+This intermediate model prevents duplicate persons in downstream models
+that join observations/medications to person data.
+*/
+
+SELECT 
+    pp.patient_id,
+    pp.person_id
+FROM {{ ref('stg_olids_patient_person') }} pp
+JOIN {{ ref('stg_olids_person') }} p
+    ON pp.person_id = p.id
+WHERE pp.patient_id IS NOT NULL
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY pp.person_id 
+    ORDER BY pp.patient_id
+) = 1
+
+ORDER BY person_id, patient_id


### PR DESCRIPTION
## Summary
• Refactored both macros to use native terminology joins instead of pre-aggregated mapped_concepts table
• Created int_patient_person_unique model to handle duplicate patient-person mappings
• Removed QUALIFY clause that was over-deduplicating and excluding valid persons
• Fixed issue where get_observations returned only 48 patients instead of expected 73

## Changes
- **get_observations macro**: Replace `stg_codesets_mapped_concepts` with native joins through `CONCEPT_MAP → CONCEPT → COMBINED_CODESETS`
- **get_medication_orders macro**: Same native join pattern + improved cluster handling
- **int_patient_person_unique model**: New intermediate model that deduplicates patient-person mappings and filters null patient_id records
- **Performance**: Removed QUALIFY clause to prevent over-deduplication while maintaining data integrity

## Technical Details
- Uses native terminology path: `OBSERVATION → CONCEPT_MAP → CONCEPT → COMBINED_CODESETS`
- Supports multi-cluster queries with separate rows per cluster (clinically correct)
- Validates person_id exists in person staging table
- Removes dependency on PATIENT table in get_observations macro

## Test plan
- [x] Verify get_observations macro returns expected 73 dementia patients (was 48)
- [x] Confirm both macros support multi-cluster queries correctly
- [x] Test int_patient_person_unique model excludes null patient_id records
- [ ] Run full dbt build to ensure no downstream model failures