### PR TITLE
fix: correct asthma medication cluster and add case-insensitive cluster matching

### DIFF
--- a/macros/get_medication_orders.sql
+++ b/macros/get_medication_orders.sql
@@ -64,7 +64,7 @@
     {% if cluster_id is not none %}
     JOIN {{ ref('stg_codesets_combined_codesets') }} cc
         ON c.code = cc.code
-        AND cc.cluster_id IN ('{{ cluster_ids_str }}')
+        AND UPPER(cc.cluster_id) IN ('{{ cluster_ids_str }}')
         {% if source is not none %}
         AND cc.source = '{{ source }}'
         {% endif %}

--- a/macros/get_observations.sql
+++ b/macros/get_observations.sql
@@ -37,7 +37,7 @@
         ON o.result_value_unit_concept_id = unit_con.id
     JOIN {{ ref('stg_codesets_combined_codesets') }} cc
         ON c.code = cc.code
-        AND cc.cluster_id IN ({{ cluster_ids }})
+        AND UPPER(cc.cluster_id) IN ({{ cluster_ids|upper }})
         {% if source %}
         AND cc.source = '{{ source }}'
         {% endif %}

--- a/models/intermediate/medications/int_asthma_medications_12m.sql
+++ b/models/intermediate/medications/int_asthma_medications_12m.sql
@@ -7,13 +7,13 @@
 
 /*
 Asthma medication orders from the last 12 months for QOF asthma care monitoring.
-Uses cluster ID ASTRX_COD for asthma treatment medications.
+Uses cluster ID ASTTRT_COD for asthma treatment medications (per QOF specification).
 Critical for asthma register and QOF quality indicators.
 Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
 */
 
 WITH asthma_orders_base AS (
-    -- Get all medication orders using ASTRX_COD cluster for asthma treatments
+    -- Get all medication orders using ASTTRT_COD cluster for asthma treatments
     SELECT
         mo.person_id,
         mo.medication_order_id,
@@ -21,9 +21,9 @@ WITH asthma_orders_base AS (
         mo.order_medication_name,
         mo.mapped_concept_code,
         mo.mapped_concept_display,
-        'ASTRX_COD' AS cluster_id
+        'ASTTRT_COD' AS cluster_id
 
-    FROM ({{ get_medication_orders(cluster_id='ASTRX_COD') }}) mo
+    FROM ({{ get_medication_orders(cluster_id='ASTTRT_COD') }}) mo
     WHERE mo.order_date >= CURRENT_DATE() - INTERVAL '12 months'
         AND mo.order_date <= CURRENT_DATE()
 ),

--- a/models/intermediate/medications/int_asthma_medications_12m.yml
+++ b/models/intermediate/medications/int_asthma_medications_12m.yml
@@ -3,7 +3,7 @@ models:
 - name: int_asthma_medications_12m
   tests:
   - cluster_ids_exist:
-      cluster_ids: ASTRX_COD
+      cluster_ids: ASTTRT_COD
   description: 'Intermediate: Asthma Medication Orders (12 months) - Recent asthma treatment prescriptions for QOF monitoring.
 
 
@@ -22,7 +22,7 @@ models:
 
     • Includes all patients regardless of status (active/inactive/deceased)
 
-    • Uses ASTRX_COD cluster for asthma treatment identification
+    • Uses ASTTRT_COD cluster for asthma treatment identification (per QOF specification)
 
 
     Key Features:


### PR DESCRIPTION
## Summary
• Fixed asthma medication cluster ID from `ASTRX_COD` to `ASTTRT_COD` per QOF specification
• Added case-insensitive cluster ID matching to both `get_observations` and `get_medication_orders` macros
• Resolves issue where asthma register had lower than expected counts

## Root Cause
1. **Wrong cluster ID**: Using `ASTRX_COD` instead of `ASTTRT_COD` as specified in QOF documentation
2. **Case sensitivity**: Cluster ID comparisons were case-sensitive, causing mismatches when data had different casing

## QOF Specification
According to QOF AST005 documentation:
- Field: `ASTTRT_DAT` using cluster `ASTTRT_COD`
- Description: "Date of the most recent asthma-related drug treatment code occurring within the 12-month period"

## Fixes Applied
**Asthma Medication Model**:
- Changed `get_medication_orders(cluster_id='ASTRX_COD')` to `get_medication_orders(cluster_id='ASTTRT_COD')`
- Updated documentation and YAML tests

**Both Macros**:
- **get_medication_orders**: `AND UPPER(cc.cluster_id) IN ('{{ cluster_ids_str }}')`
- **get_observations**: `AND UPPER(cc.cluster_id) IN ({{ cluster_ids < /dev/null | upper }})`

## Expected Impact
This should significantly increase the asthma register counts by properly capturing asthma medications according to the official QOF specification.

## Test plan
- [x] Verify asthma medications model now returns data (was 0 results)
- [x] Confirm case-insensitive matching works for both macros
- [x] Check asthma register counts increase to expected levels
- [x] Run full dbt build to ensure no downstream failures