### PR TITLE
refactor: remove ECL cache support from get_medication_orders macro

### DIFF
--- a/models/intermediate/medications/int_epilepsy_medications_6m.sql
+++ b/models/intermediate/medications/int_epilepsy_medications_6m.sql
@@ -7,7 +7,7 @@
 
 /*
 Epilepsy medication orders from the last 6 months for seizure management monitoring.
-Uses cluster ID EPILDRUG_COD for anti-epileptic drugs from Primary Care Domain.
+Uses cluster ID EPILDRUG_COD for anti-epileptic drugs.
 Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
 */
 
@@ -30,7 +30,7 @@ SELECT
     bnf_name,
     cluster_id
 FROM (
-    {{ get_medication_orders(ecl_cluster='epildrug_cod') }}
+    {{ get_medication_orders(cluster_id='EPILDRUG_COD') }}
 ) base_orders
 WHERE order_date >= CURRENT_DATE() - INTERVAL '6 months'
 ORDER BY person_id, order_date DESC


### PR DESCRIPTION
## Summary
• Removed ECL cache support from `get_medication_orders` macro
• Updated `int_epilepsy_medications_6m` to use standard cluster_id parameter
• Fixed case-insensitive cluster matching in the macro
• Simplifies macro interface and reduces dependencies

## Changes
- **Removed**: `ecl_cluster` parameter and `ECL_CACHED_DETAILS` join
- **Updated**: `int_epilepsy_medications_6m` from `ecl_cluster='epildrug_cod'` to `cluster_id='EPILDRUG_COD'`
- **Fixed**: Ensured case-insensitive cluster matching works properly

## Rationale
ECL data now feeds directly into `combined_codesets`, making the ECL cache functionality redundant. This simplification:
- Reduces macro complexity
- Eliminates dependency on ECL cache table function
- Standardizes all code lookups through `combined_codesets`

## Test plan
- [x] Verify epilepsy medications model still returns data after change
- [x] Confirm case-insensitive cluster matching works
- [ ] Run full dbt build to ensure no other models are affected