### PR TITLE
fix: correct DIASBP_COD cluster ID typo in blood pressure models

### DIFF
--- a/models/intermediate/observations/int_blood_pressure_all.sql
+++ b/models/intermediate/observations/int_blood_pressure_all.sql
@@ -19,7 +19,7 @@ WITH base_observations_and_clusters AS (
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,
         obs.cluster_id AS source_cluster_id
-    FROM ({{ get_observations("'BP_COD', 'SYSBP_COD', 'DIABP_COD', 'HOMEAMBBP_COD', 'ABPM_COD', 'HOMEBP_COD'") }}) obs
+    FROM ({{ get_observations("'BP_COD', 'SYSBP_COD', 'DIASBP_COD', 'HOMEAMBBP_COD', 'ABPM_COD', 'HOMEBP_COD'") }}) obs
     WHERE obs.result_value IS NOT NULL
       AND obs.clinical_effective_date IS NOT NULL
       AND obs.clinical_effective_date <= CURRENT_DATE() -- No future dates
@@ -37,7 +37,7 @@ row_flags AS (
          (source_cluster_id = 'BP_COD' AND concept_display ILIKE '%systolic%')) AS is_systolic_row,
 
         -- Flag for Diastolic readings: specific cluster or display text contains 'diastolic'
-        (source_cluster_id = 'DIABP_COD' OR
+        (source_cluster_id = 'DIASBP_COD' OR
          (source_cluster_id = 'BP_COD' AND concept_display ILIKE '%diastolic%')) AS is_diastolic_row,
 
         -- Flag for Home BP context

--- a/models/intermediate/observations/int_blood_pressure_all.yml
+++ b/models/intermediate/observations/int_blood_pressure_all.yml
@@ -5,4 +5,4 @@ models:
     tests:
       - cluster_ids_exist:
           arguments:
-            cluster_ids: ABPM_COD, BP_COD, DIABP_COD, HOMEAMBBP_COD, HOMEBP_COD, SYSBP_COD
+            cluster_ids: ABPM_COD, BP_COD, DIASBP_COD, HOMEAMBBP_COD, HOMEBP_COD, SYSBP_COD

--- a/models/marts/data_quality/dq_blood_pressure_issues.sql
+++ b/models/marts/data_quality/dq_blood_pressure_issues.sql
@@ -21,7 +21,7 @@ WITH base_observations_raw AS (
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,
         obs.cluster_id AS source_cluster_id
-    FROM ({{ get_observations("'BP_COD', 'SYSBP_COD', 'DIABP_COD', 'HOMEAMBBP_COD', 'ABPM_COD', 'HOMEBP_COD'") }}) obs
+    FROM ({{ get_observations("'BP_COD', 'SYSBP_COD', 'DIASBP_COD', 'HOMEAMBBP_COD', 'ABPM_COD', 'HOMEBP_COD'") }}) obs
     WHERE obs.result_value IS NOT NULL -- Still need a value to assess
     -- DO NOT filter dates or values here - we want to catch issues
 ),
@@ -35,7 +35,7 @@ row_flags_raw AS (
          (source_cluster_id = 'BP_COD' AND concept_display ILIKE '%systolic%')) AS is_systolic_row,
 
         -- Flag for Diastolic readings
-        (source_cluster_id = 'DIABP_COD' OR
+        (source_cluster_id = 'DIASBP_COD' OR
          (source_cluster_id = 'BP_COD' AND concept_display ILIKE '%diastolic%')) AS is_diastolic_row
     FROM base_observations_raw
 ),
@@ -59,7 +59,7 @@ aggregated_raw_events AS (
 
         -- Flags for specific code presence (for ambiguity checking)
         BOOLOR_AGG(source_cluster_id = 'SYSBP_COD') AS had_sysbp_cod,
-        BOOLOR_AGG(source_cluster_id = 'DIABP_COD') AS had_diabp_cod
+        BOOLOR_AGG(source_cluster_id = 'DIASBP_COD') AS had_diabp_cod
 
     FROM row_flags_raw
     GROUP BY person_id, clinical_effective_date

--- a/models/marts/data_quality/dq_blood_pressure_issues.yml
+++ b/models/marts/data_quality/dq_blood_pressure_issues.yml
@@ -15,4 +15,4 @@ models:
     tests:
       - cluster_ids_exist:
           arguments:
-            cluster_ids: ABPM_COD, BP_COD, DIABP_COD, HOMEAMBBP_COD, HOMEBP_COD, SYSBP_COD
+            cluster_ids: ABPM_COD, BP_COD, DIASBP_COD, HOMEAMBBP_COD, HOMEBP_COD, SYSBP_COD

--- a/start_dbt.ps1
+++ b/start_dbt.ps1
@@ -1,4 +1,7 @@
   # start_dbt.ps1
+  # Activate virtual environment first
+  & "venv\Scripts\Activate.ps1"
+
   # Load project-specific environment variables
   Get-Content ".env" | ForEach-Object {
     if ($_ -match '^([^=]+)=(.*)$' -and -not $_.StartsWith('#')) {


### PR DESCRIPTION
## Summary

• Fixed typo in cluster ID from `DIABP_COD` to `DIASBP_COD` across blood pressure models
• Updated both intermediate and data quality models for consistency
• Enhanced PowerShell script to activate virtual environment before loading .env

## Changes

### Blood Pressure Models
- **int_blood_pressure_all.sql**: Corrected cluster ID in get_observations macro call and row flag logic
- **int_blood_pressure_all.yml**: Updated cluster ID in tests
- **dq_blood_pressure_issues.sql**: Fixed cluster ID references throughout
- **dq_blood_pressure_issues.yml**: Updated cluster ID in tests

### Environment Setup
- **start_dbt.ps1**: Added virtual environment activation before loading environment variables

## Test Plan

- [ ] Run dbt compile to ensure models compile successfully
- [ ] Run dbt test to verify cluster ID existence tests pass
- [ ] Verify blood pressure data quality checks work with correct cluster ID
- [ ] Test start_dbt.ps1 script activates virtual environment properly