### PR TITLE
docs: clarify business logic in population_health_needs_base

### DIFF
--- a/models/marts/published_reporting_direct_care/population_health_needs_base.sql
+++ b/models/marts/published_reporting_direct_care/population_health_needs_base.sql
@@ -8,12 +8,11 @@ Complete population health foundation combining demographics, behavioural risk f
 Provides comprehensive analytical dataset for population health dashboards and reporting.
 
 Business Logic:
-- All three tables designed with identical grain (one row per person from dim_person)
+- All three source tables designed with identical grain (one row per person from dim_person)
 - LEFT JOINs from demographics ensure complete population coverage (defensive approach)
 - Demographics: Complete population with full demographic profiles (base table)
 - Behavioural risk factors: All persons with explicit data availability flags (NULL where no assessments)
 - Conditions: All persons with explicit TRUE/FALSE flags (FALSE where no conditions)
-- Maintains full demographic population while safely handling any data loading edge cases
 */
 
 SELECT


### PR DESCRIPTION
Update comments to specify that all three source tables are designed with identical grain, ensuring clarity in the dataset's structure and maintaining a defensive approach with LEFT JOINs for comprehensive population coverage.