### PR TITLE
refactor: simplify BMI models and move risk sort key to base model

### DIFF
--- a/models/intermediate/observations/int_bmi_all.sql
+++ b/models/intermediate/observations/int_bmi_all.sql
@@ -140,7 +140,18 @@ SELECT
         WHEN bmi_value < 35 THEN 'Obese Class I'
         WHEN bmi_value < 40 THEN 'Obese Class II'
         ELSE 'Obese Class III'
-    END AS bmi_category
+    END AS bmi_category,
+
+    -- BMI risk sort key (higher number = higher risk)
+    CASE
+        WHEN bmi_value NOT BETWEEN 5 AND 400 THEN 0  -- Invalid
+        WHEN bmi_value < 18.5 THEN 2  -- Underweight - Health risk
+        WHEN bmi_value < 25 THEN 1  -- Normal - Baseline/lowest risk
+        WHEN bmi_value < 30 THEN 3  -- Overweight - Moderate risk
+        WHEN bmi_value < 35 THEN 4  -- Obese Class I - High risk
+        WHEN bmi_value < 40 THEN 5  -- Obese Class II - Higher risk
+        ELSE 6  -- Obese Class III - Highest risk
+    END AS bmi_risk_sort_key
 
 FROM all_bmi
 

--- a/models/intermediate/observations/int_bmi_latest.sql
+++ b/models/intermediate/observations/int_bmi_latest.sql
@@ -6,7 +6,7 @@
 
 /*
 Latest valid BMI measurement per person.
-Uses the int_bmi_all model and filters to most recent valid BMI and adds a sort key for BMI risk.
+Uses the int_bmi_all model and filters to most recent valid BMI.
 */
 
 SELECT
@@ -20,23 +20,9 @@ SELECT
     bmi_category,
     original_result_value,
     is_valid_bmi,
-    
-    -- BMI risk sort key (higher number = higher risk)
-    CASE bmi_category
-        WHEN 'Underweight' THEN 2  -- Health risk
-        WHEN 'Normal' THEN 1  -- Baseline/lowest risk
-        WHEN 'Overweight' THEN 3  -- Moderate risk
-        WHEN 'Obese Class I' THEN 4  -- High risk
-        WHEN 'Obese Class II' THEN 5  -- Higher risk
-        WHEN 'Obese Class III' THEN 6  -- Highest risk
-        ELSE 0  -- Unknown
-    END AS bmi_risk_sort_key
+    bmi_source,
+    bmi_risk_sort_key
 
-FROM (
-    {{ get_latest_events(
-        ref('int_bmi_all'),
-        partition_by=['person_id'],
-        order_by=['clinical_effective_date']
-    ) }}
-)
+FROM {{ ref('int_bmi_all') }}
 WHERE is_valid_bmi = TRUE
+QUALIFY ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY clinical_effective_date DESC) = 1


### PR DESCRIPTION
Improves model architecture and performance:
- Move BMI risk sort key from int_bmi_latest to int_bmi_all for consistency
- Replace get_latest_events macro with simple QUALIFY clause in int_bmi_latest
- Add bmi_source field to latest model for transparency
- Simplifies SQL and improves readability