### PR TITLE
refactor: rename original_result_value to result_value in BMI models

### DIFF
--- a/models/intermediate/observations/int_bmi_all.sql
+++ b/models/intermediate/observations/int_bmi_all.sql
@@ -21,7 +21,7 @@ WITH recorded_bmi AS (
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,
         obs.cluster_id AS source_cluster_id,
-        obs.result_value AS original_result_value,
+        obs.result_value,
         'recorded' AS bmi_source
 
     FROM ({{ get_observations("'BMIVAL_COD'") }}) obs
@@ -99,7 +99,7 @@ calculated_bmi AS (
         'CALCULATED_BMI' AS concept_code,
         'Calculated BMI from Height/Weight' AS concept_display,
         'CALCULATED' AS source_cluster_id,
-        CAST(hw.calculated_bmi AS VARCHAR(20)) AS original_result_value,
+        CAST(hw.calculated_bmi AS VARCHAR(20)) AS result_value,
         'calculated' AS bmi_source
     FROM height_weight_pairs hw
     WHERE hw.calculated_bmi IS NOT NULL
@@ -122,7 +122,7 @@ SELECT
     concept_code,
     concept_display,
     source_cluster_id,
-    original_result_value,
+    result_value,
     bmi_source,
 
     -- Data quality validation

--- a/models/intermediate/observations/int_bmi_latest.sql
+++ b/models/intermediate/observations/int_bmi_latest.sql
@@ -18,7 +18,7 @@ SELECT
     concept_display,
     source_cluster_id,
     bmi_category,
-    original_result_value,
+    result_value,
     is_valid_bmi,
     bmi_source,
     bmi_risk_sort_key

--- a/models/intermediate/observations/int_bmi_qof.sql
+++ b/models/intermediate/observations/int_bmi_qof.sql
@@ -19,7 +19,7 @@ WITH base_observations AS (
         obs.mapped_concept_code AS concept_code,
         obs.mapped_concept_display AS concept_display,
         obs.cluster_id AS source_cluster_id,
-        obs.result_value AS original_result_value,
+        obs.result_value,
 
         -- Extract BMI value from result_value, handling both numeric and coded values
         CASE
@@ -115,7 +115,7 @@ SELECT
     lo.is_bmi_27_5_plus,
     lo.is_bmi_25_plus,
     lo.is_valid_bmi,
-    lo.original_result_value,
+    lo.result_value,
 
     -- Person-level aggregated data
     pla.latest_bmi_date,

--- a/models/marts/data_quality/dq_bmi_issues.sql
+++ b/models/marts/data_quality/dq_bmi_issues.sql
@@ -25,7 +25,7 @@ SELECT
     concept_code,
     concept_display,
     source_cluster_id,
-    original_result_value,
+    result_value,
     bmi_category,
     
     -- DQ Flags based on our updated ranges


### PR DESCRIPTION
Improves field naming consistency across BMI models:
- int_bmi_all: Updated both recorded and calculated BMI sections
- int_bmi_latest: Updated field reference
- int_bmi_qof: Updated assignment and selection
- dq_bmi_issues: Updated field reference

The simplified name 'result_value' is more intuitive than 'original_result_value'. All downstream models tested successfully.