### PR TITLE
fix: suppress dbt1000 unsafe introspection warnings

### DIFF
--- a/macros/get_medication_orders.sql
+++ b/macros/get_medication_orders.sql
@@ -1,4 +1,6 @@
 {% macro get_medication_orders(bnf_code=none, cluster_id=none, source=none) %}
+    {% do config(static_analysis='unsafe') %}
+    
     -- Simpler: emit a single SELECT, no CTEs, cluster_id IN (...), always includes cluster_id in output
     -- Optional source parameter to filter to specific refset (e.g., 'LTC_LCS')
     {% if bnf_code is none and cluster_id is none %}

--- a/macros/get_observations.sql
+++ b/macros/get_observations.sql
@@ -1,4 +1,6 @@
 {% macro get_observations(cluster_ids, source=none) %}
+    {% do config(static_analysis='unsafe') %}
+    
     {%- if cluster_ids is none or cluster_ids|trim == '' -%}
         {{ exceptions.raise_compiler_error("Must provide a non-empty cluster_ids parameter to get_observations macro") }}
     {%- endif -%}


### PR DESCRIPTION
## Summary

• Add `static_analysis='unsafe'` configuration to `get_observations` and `get_medication_orders` macros
• Automatically suppresses dbt1000 warnings for models using these macros
• Resolves non-deterministic static analysis warnings caused by runtime introspection

## Background

The `get_observations` and `get_medication_orders` macros use `adapter.get_relation()` to check for materialized view variants at parse time. This runtime introspection creates non-deterministic static analysis, triggering dbt1000 warnings across 90+ models.

## Solution

By adding `{% do config(static_analysis='unsafe') %}` to both macros, any model calling these macros automatically receives the configuration. This approach is:

• **Centralized**: Managed in just 2 macros rather than 90+ models
• **Automatic**: No model file changes required  
• **Targeted**: Only affects models that perform unsafe introspection
• **Future-proof**: New models using these macros inherit the config

## Test Plan

- [x] Verify macros compile correctly
- [x] Confirm dbt1000 warnings are suppressed
- [x] Test with existing models using these macros