### PR TITLE
feat: improve analysis reporting with month-end dates and CKD patterns

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -51,7 +51,7 @@ SELECT
 FROM {{ ref('person_month_analysis_base') }}
 WHERE financial_year = '2025/26' -- date spine                                   
 GROUP BY ALL
-HAVING COUNT(DISTINCT person_id) >= 100  -- statistical validity
+HAVING COUNT(DISTINCT CASE WHEN has_ckd THEN person_id END) > 5  -- Small number suppression
 ORDER BY practice_neighbourhood, ckd_prevalence_pct DESC
 ```
 

--- a/analysis/practice_neighbourhood_analysis.sql
+++ b/analysis/practice_neighbourhood_analysis.sql
@@ -30,7 +30,7 @@ FROM {{ ref('person_month_analysis_base') }}
 WHERE analysis_month = (SELECT MAX(analysis_month) FROM {{ ref('person_month_analysis_base') }})
     AND practice_neighbourhood IS NOT NULL
 GROUP BY ALL
-HAVING COUNT(DISTINCT person_id) >= 1000  -- Adequate sample size
+HAVING COUNT(DISTINCT CASE WHEN has_dm THEN person_id END) > 5  -- Small number suppression
 ORDER BY diabetes_prevalence_pct DESC;
 
 -- =============================================================================
@@ -48,7 +48,7 @@ FROM {{ ref('person_month_analysis_base') }}
 WHERE analysis_month = (SELECT MAX(analysis_month) FROM {{ ref('person_month_analysis_base') }})
     AND practice_neighbourhood IS NOT NULL
 GROUP BY ALL
-HAVING COUNT(DISTINCT person_id) >= 500  -- Meaningful practice size
+HAVING COUNT(DISTINCT person_id) > 5  -- Small number suppression
 ORDER BY practice_neighbourhood, list_size DESC;
 
 -- =============================================================================
@@ -84,5 +84,5 @@ SELECT
 FROM {{ ref('person_month_analysis_base') }}
 WHERE practice_neighbourhood IS NOT NULL
 GROUP BY ALL
-HAVING COUNT(DISTINCT person_id) >= 1000  -- Adequate sample size
+HAVING COUNT(DISTINCT CASE WHEN has_dm THEN person_id END) > 5  -- Small number suppression
 ORDER BY practice_neighbourhood, financial_year;


### PR DESCRIPTION
## Summary

• Updates person_month_analysis_base to use month-end dates for more accurate financial year reporting
• Adds CKD prevalence analysis patterns by neighbourhood and ethnicity
• Implements small number suppression for patient confidentiality

## Changes

### Month-End Date Reporting
- Modified `person_month_analysis_base.sql` to use `month_end_date` instead of `month_start_date` for the `analysis_month` field
- This provides accurate financial year-end positions (31st March) for NHS reporting

### New CKD Analysis Patterns
- **Pattern 5**: CKD prevalence by practice neighbourhood and ethnicity category
- **Pattern 6**: CKD prevalence by neighbourhood over time (FY end positions)

### Small Number Suppression
- Replaced minimum sample size checks with small number suppression (>5 cases)
- Applied to all HAVING clauses in analysis files for better patient confidentiality

## Impact
- The `person_month_analysis_base` table will need to be rebuilt with `dbt run --full-refresh`
- Analysis queries now accurately represent month-end positions for financial reporting

## Test Plan
- [x] Run `dbt run --full-refresh -s person_month_analysis_base` to rebuild the table
- [x] Test the updated analysis queries to verify CKD patterns work correctly
- [x] Confirm small number suppression is working as expected