### PR TITLE
feat: standardise practice names and reorder demographics columns

### DIFF
--- a/macros/clean_practice_name.sql
+++ b/macros/clean_practice_name.sql
@@ -1,0 +1,15 @@
+{% macro clean_practice_name(organisation_name_field, fallback_field) %}
+    {% set medical_acronyms = [
+        'GP', 'NHS', 'PMS', 'HESA', 'PHGH', 'H/C', 'CCG', 'ICB', 'PCN', 'LP'
+    ] %}
+    
+    -- Use organisation_name (preserve existing casing) or convert fallback to proper case
+    {% set base_name = 'COALESCE(' + organisation_name_field + ', INITCAP(' + fallback_field + '))' %}
+    {% set cleaned_name = 'TRIM(' + base_name + ", '.')" %}
+    
+    {% for acronym in medical_acronyms %}
+        {% set cleaned_name = "REGEXP_REPLACE(" + cleaned_name + ", '\\\\b" + acronym + "\\\\b', '" + acronym + "', 'gi')" %}
+    {% endfor %}
+    
+    {{ cleaned_name }}
+{% endmacro %}

--- a/models/olids/intermediate/person_attributes/int_patient_registrations.sql
+++ b/models/olids/intermediate/person_attributes/int_patient_registrations.sql
@@ -36,7 +36,7 @@ raw_registrations AS (
         prpr.practitioner_id,
         prpr.episode_of_care_id,
         -- Get practice details
-        UPPER(o.name) AS practice_name,
+        COALESCE(dp.practice_name, o.name) AS practice_name,  -- Use practice name from dim_practice
         o.organisation_code AS practice_ods_code,
         -- Get patient details
         p.sk_patient_id
@@ -45,6 +45,8 @@ raw_registrations AS (
         ON prpr.patient_id = ptp.patient_id
     LEFT JOIN {{ ref('stg_olids_organisation') }} AS o
         ON prpr.organisation_id = o.id
+    LEFT JOIN {{ ref('dim_practice') }} AS dp
+        ON o.organisation_code = dp.practice_code
     LEFT JOIN {{ ref('stg_olids_patient') }} AS p
         ON prpr.patient_id = p.id
     WHERE prpr.start_date IS NOT NULL

--- a/models/olids/marts/organisation/dim_practice.sql
+++ b/models/olids/marts/organisation/dim_practice.sql
@@ -17,7 +17,7 @@ SELECT
     
     -- Practice details
     dict.practicecode AS practice_code,
-    UPPER(dict.practicename) AS practice_name,
+    {{ clean_practice_name('dict_org.organisation_name', 'dict.practicename') }} AS practice_name,
     
     -- PCN details
     dict.networkcode AS pcn_code,

--- a/models/olids/marts/person_demographics/dim_person_demographics.sql
+++ b/models/olids/marts/person_demographics/dim_person_demographics.sql
@@ -93,6 +93,17 @@ SELECT
     bd.person_id,
     bd.sk_patient_id,
 
+    -- Status Flags (key person attributes)
+    COALESCE(cr.is_current_registration, FALSE) AS is_active,
+    bd.is_deceased,
+    bd.is_dummy_patient,
+    CASE 
+        WHEN bd.is_deceased THEN 'Deceased'
+        WHEN cr.is_current_registration = FALSE THEN 'Registration ended'
+        WHEN cr.practice_code IS NULL THEN 'No registration history'
+        ELSE NULL
+    END AS inactive_reason,
+
     -- Basic Demographics from dim_person_birth_death
     bd.birth_year,
     bd.birth_date_approx,
@@ -103,7 +114,6 @@ SELECT
     END AS birth_date_approx_end_of_month,
     bd.death_year,
     bd.death_date_approx,
-    bd.is_deceased,
     
     -- Age calculations (current as of today or death date)
     CASE 
@@ -153,14 +163,6 @@ SELECT
     
     -- Sex from dim_person_sex
     COALESCE(sex.sex, 'Unknown') AS sex,
-
-    -- Active Status based on current registration
-    COALESCE(cr.is_current_registration, FALSE) AS is_active,
-    CASE 
-        WHEN cr.is_current_registration = FALSE THEN 'Registration ended'
-        WHEN cr.practice_code IS NULL THEN 'No registration history'
-        ELSE NULL
-    END AS inactive_reason,
 
     -- Ethnicity from latest recording
     COALESCE(le.ethnicity_category, 'Unknown') AS ethnicity_category,

--- a/models/olids/marts/person_demographics/dim_person_demographics_historical.sql
+++ b/models/olids/marts/person_demographics/dim_person_demographics_historical.sql
@@ -138,6 +138,16 @@ SELECT
     pm.person_id,
     bd.sk_patient_id,
     
+    -- Status Flags (key person attributes for this month)
+    pm.is_active,
+    bd.is_deceased,
+    bd.is_dummy_patient,
+    CASE 
+        WHEN bd.is_deceased AND bd.death_date_approx <= pm.analysis_month THEN 'Deceased'
+        WHEN pm.is_active = FALSE THEN 'Registration ended'
+        ELSE NULL
+    END AS inactive_reason,
+    
     -- Birth and death information
     bd.birth_year,
     bd.birth_month,
@@ -151,7 +161,6 @@ SELECT
     bd.death_year,
     bd.death_month,
     bd.death_date_approx,
-    bd.is_deceased,
     
     -- Age calculated for this specific month
     CASE 
@@ -344,13 +353,6 @@ SELECT
     
     -- Sex
     COALESCE(sex.sex, 'Unknown') AS sex,
-    
-    -- Active registration status for this month
-    pm.is_active,
-    CASE 
-        WHEN pm.is_active = FALSE THEN 'Registration ended'
-        ELSE NULL
-    END AS inactive_reason,
     
     -- Ethnicity as recorded by this month
     COALESCE(me.ethnicity_category, 'Unknown') AS ethnicity_category,


### PR DESCRIPTION
## Summary

• Standardise practice names with medical acronym capitalisation
• Reorder demographics columns - status flags after identifiers  
• Fix inactive_reason to prioritise death over registration status

## Changes

• Add clean_practice_name macro - removes trailing dots, capitalises GP/NHS/PMS etc
• Move is_active, is_deceased, is_dummy_patient after person_id in both demographics models
• Deceased patients show 'Deceased' not 'Registration ended' in inactive_reason