### PR TITLE
feat: simplify cervical screening models

### DIFF
--- a/analysis/flu_timeseries_sample_queries.sql
+++ b/analysis/flu_timeseries_sample_queries.sql
@@ -1,0 +1,169 @@
+/*
+Sample Queries for Flu Timeseries Models
+
+These queries demonstrate the analytical capabilities of the new flu timeseries
+models and serve as tests to ensure the models are working correctly.
+*/
+
+-- Query 1: Organisational Hierarchy - Borough Level Rollup
+-- Shows current campaign progress by borough
+SELECT 
+    practice_borough,
+    week_number,
+    SUM(eligible_count) as total_eligible,
+    SUM(cumulative_vaccination_count) as total_vaccinated,
+    ROUND(100.0 * SUM(cumulative_vaccination_count) / SUM(eligible_count), 1) as borough_uptake_rate
+FROM {{ ref('fct_flu_weekly_org') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND is_latest_week = TRUE
+GROUP BY practice_borough, week_number
+ORDER BY borough_uptake_rate DESC;
+
+-- Query 2: PCN Performance Comparison
+-- Shows current vs previous year performance by PCN
+SELECT 
+    pcn_name,
+    week_number,
+    current_cumulative_vaccinations,
+    previous_cumulative_vaccinations,
+    vaccinations_ahead_behind,
+    position_vs_last_year,
+    current_trajectory
+FROM {{ ref('flu_weekly_comparison') }}
+WHERE week_number = (
+    SELECT MAX(week_number) 
+    FROM {{ ref('flu_weekly_comparison') }}
+    WHERE comparison_type LIKE 'Week%'
+)
+ORDER BY vaccinations_ahead_behind DESC;
+
+-- Query 3: Complex Demographic Filtering (PowerBI Use Case)
+-- Shows uptake for diabetic patients over 65 by ethnicity
+SELECT 
+    ethnicity_category,
+    practice_borough,
+    COUNT(DISTINCT person_id) as eligible_diabetic_over_65,
+    SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) as vaccinated_count,
+    ROUND(100.0 * SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) / COUNT(DISTINCT person_id), 1) as uptake_rate
+FROM {{ ref('fct_flu_weekly_person') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND is_latest_week = TRUE
+    AND has_diabetes = TRUE
+    AND is_over_65 = TRUE
+GROUP BY ethnicity_category, practice_borough
+HAVING COUNT(DISTINCT person_id) >= 10  -- Privacy threshold
+ORDER BY uptake_rate DESC;
+
+-- Query 4: Weekly Vaccination Velocity by Practice
+-- Shows weekly vaccination counts and cumulative progress
+SELECT 
+    practice_name,
+    week_number,
+    weekly_vaccination_count,
+    cumulative_vaccination_count,
+    uptake_rate_percent,
+    campaign_phase
+FROM {{ ref('fct_flu_weekly_org') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND practice_code = 'M85001'  -- Example practice
+ORDER BY week_number;
+
+-- Query 5: Risk Group Analysis - Multiple Conditions
+-- Shows uptake for people with multiple risk factors
+SELECT 
+    CASE 
+        WHEN has_diabetes AND has_heart_disease THEN 'Diabetes + Heart Disease'
+        WHEN has_diabetes AND has_respiratory_disease THEN 'Diabetes + Respiratory'
+        WHEN has_diabetes THEN 'Diabetes Only'
+        WHEN has_heart_disease THEN 'Heart Disease Only'
+        WHEN has_respiratory_disease THEN 'Respiratory Only'
+        ELSE 'Other Clinical'
+    END as risk_group_combination,
+    COUNT(DISTINCT person_id) as eligible_count,
+    SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) as vaccinated_count,
+    ROUND(100.0 * SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) / COUNT(DISTINCT person_id), 1) as uptake_rate
+FROM {{ ref('fct_flu_weekly_person') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND is_latest_week = TRUE
+    AND is_clinical_eligible = TRUE
+GROUP BY 1
+ORDER BY uptake_rate DESC;
+
+-- Query 6: Campaign Progress Timeline - Week by Week
+-- Shows vaccination progress week by week for current campaign
+SELECT 
+    week_number,
+    week_start_date,
+    SUM(weekly_vaccination_count) as new_vaccinations_this_week,
+    SUM(cumulative_vaccination_count) as total_vaccinations_to_date,
+    SUM(eligible_count) as total_eligible,
+    ROUND(100.0 * SUM(cumulative_vaccination_count) / SUM(eligible_count), 1) as cumulative_uptake_rate
+FROM {{ ref('fct_flu_weekly_org') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+GROUP BY week_number, week_start_date
+ORDER BY week_number;
+
+-- Query 7: Deprivation Analysis
+-- Shows uptake by deprivation decile
+SELECT 
+    imd_decile_19,
+    COUNT(DISTINCT person_id) as eligible_count,
+    SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) as vaccinated_count,
+    ROUND(100.0 * SUM(CASE WHEN is_vaccinated THEN 1 ELSE 0 END) / COUNT(DISTINCT person_id), 1) as uptake_rate
+FROM {{ ref('fct_flu_weekly_person') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND is_latest_week = TRUE
+    AND imd_decile_19 IS NOT NULL
+GROUP BY imd_decile_19
+ORDER BY imd_decile_19;
+
+-- Query 8: Vaccination Timing Analysis
+-- Shows when people got vaccinated during the campaign
+SELECT 
+    week_number,
+    campaign_phase,
+    COUNT(DISTINCT person_id) as people_vaccinated_this_week,
+    SUM(COUNT(DISTINCT person_id)) OVER (ORDER BY week_number) as cumulative_people_vaccinated,
+    ROUND(
+        100.0 * COUNT(DISTINCT person_id) / 
+        SUM(COUNT(DISTINCT person_id)) OVER (), 
+        1
+    ) as percentage_of_total_vaccinations
+FROM {{ ref('fct_flu_weekly_person') }}
+WHERE campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+    AND vaccination_occurred_this_week = TRUE
+GROUP BY week_number, campaign_phase
+ORDER BY week_number;
+
+-- Query 9: Practice Performance Rankings
+-- Shows practice rankings by improvement vs last year
+SELECT 
+    practice_name,
+    pcn_name,
+    practice_borough,
+    current_cumulative_vaccinations,
+    previous_cumulative_vaccinations,
+    vaccinations_ahead_behind,
+    percentage_change_vaccinations,
+    practice_rank_improvement,
+    current_trajectory
+FROM {{ ref('flu_weekly_comparison') }}
+WHERE week_number = (
+    SELECT MAX(week_number) 
+    FROM {{ ref('flu_weekly_comparison') }}
+    WHERE comparison_type LIKE 'Week%'
+)
+    AND practice_rank_improvement <= 10  -- Top 10 improvers
+ORDER BY practice_rank_improvement;
+
+-- Query 10: Data Quality Check - Sparse Table Efficiency
+-- Shows the efficiency of the sparse approach
+SELECT 
+    campaign_id,
+    COUNT(*) as sparse_records,
+    COUNT(DISTINCT person_id) as unique_persons,
+    COUNT(DISTINCT week_number) as weeks_with_data,
+    ROUND(COUNT(*) / (COUNT(DISTINCT person_id) * COUNT(DISTINCT week_number)), 2) as sparsity_ratio
+FROM {{ ref('int_flu_person_week_snapshot') }}
+GROUP BY campaign_id
+ORDER BY campaign_id;

--- a/macros/flu/flu_campaign_config.sql
+++ b/macros/flu/flu_campaign_config.sql
@@ -38,7 +38,7 @@ CHILD AGE GROUPS:
             '2023-09-01'::DATE AS campaign_start_date,
             '2024-03-31'::DATE AS campaign_reference_date, 
             '2023-08-31'::DATE AS child_reference_date,
-            '2024-02-29'::DATE AS campaign_end_date,
+            '2024-03-31'::DATE AS campaign_end_date,
             
             -- Medication lookback dates
             '2022-09-01'::DATE AS asthma_medication_lookback_date,

--- a/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_all.sql
+++ b/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_all.sql
@@ -26,7 +26,6 @@ Key Business Rules:
 
 Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
 This is OBSERVATION-LEVEL data - one row per cervical screening observation.
-Use this model as input for int_cervical_screening_latest.sql and fct_cervical_screening_status.sql.
 */
 
 SELECT
@@ -46,110 +45,13 @@ SELECT
         ELSE 'Unknown'
     END AS screening_observation_type,
 
-    -- Simple screening type flags
+    -- Simple screening type flags based on core cluster codes
     CASE WHEN obs.cluster_id = 'SMEAR_COD' THEN TRUE ELSE FALSE END AS is_completed_screening,
     CASE WHEN obs.cluster_id = 'CSPU_COD' THEN TRUE ELSE FALSE END AS is_unsuitable_screening,
     CASE WHEN obs.cluster_id = 'CSDEC_COD' THEN TRUE ELSE FALSE END AS is_declined_screening,
-    CASE WHEN obs.cluster_id = 'CSPCAINVITE_COD' THEN TRUE ELSE FALSE END AS is_non_response_screening,
-
-    -- Cytology result categorisation for SMEAR_COD (static code interpretation)
-    CASE
-        WHEN obs.cluster_id != 'SMEAR_COD' THEN NULL
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%normal%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%negative%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%no abnormality%' THEN 'Normal'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%borderline%' THEN 'Borderline Changes'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%mild dyskaryosis%' THEN 'Mild Dyskaryosis'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%moderate dyskaryosis%' THEN 'Moderate Dyskaryosis'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%severe dyskaryosis%' THEN 'Severe Dyskaryosis'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%cannot exclude invasive%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%invasive carcinoma%' THEN 'Severe Dyskaryosis - ?Invasive'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%glandular neoplasia%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%cannot exclude glandular%' THEN 'Glandular Abnormality'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%inflammatory%' THEN 'Inflammatory Changes'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%atrophic%' THEN 'Atrophic Changes'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%endocervical cells present%' THEN 'Adequate Sample'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%trichomonas%' THEN 'Trichomonas Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%candida%' THEN 'Candida Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%herpes%' THEN 'Herpes Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%actinomyces%' THEN 'Actinomyces Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%gardnerella%' THEN 'Gardnerella Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%koilocytosis%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%viral%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%wart virus%' THEN 'Viral Changes (HPV)'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%action needed%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%colposcopy%' THEN 'Referral Required'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%nuclear abnormality%' THEN 'Nuclear Abnormality'
-        ELSE 'Screening Completed'
-    END AS cytology_result_category,
-
-    -- Clinical risk assessment based on cytology results (static interpretation)
-    CASE
-        WHEN obs.cluster_id != 'SMEAR_COD' THEN NULL
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%normal%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%negative%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%no abnormality%' THEN 'Low Risk (Normal)'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%borderline%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%mild dyskaryosis%' THEN 'Low-Moderate Risk'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%moderate dyskaryosis%' THEN 'Moderate Risk'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%severe dyskaryosis%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%cannot exclude invasive%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%glandular neoplasia%' THEN 'High Risk (Abnormal)'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%action needed%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%colposcopy%' THEN 'Requires Clinical Assessment'
-        ELSE 'Risk Assessment Required'
-    END AS cervical_screening_risk_category,
-
-    -- Abnormality grade classification
-    CASE
-        WHEN obs.cluster_id != 'SMEAR_COD' THEN NULL
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%normal%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%negative%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%no abnormality%' THEN 'Normal'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%borderline%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%mild dyskaryosis%' THEN 'Low Grade'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%moderate dyskaryosis%' THEN 'Moderate Grade'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%severe dyskaryosis%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%cannot exclude invasive%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%glandular neoplasia%' THEN 'High Grade'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%koilocytosis%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%viral%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%wart virus%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%hpv%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%human papilloma%' THEN 'HPV Changes'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%trichomonas%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%candida%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%herpes%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%actinomyces%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%gardnerella%' THEN 'Infection'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%inflammatory%' THEN 'Inflammatory'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%atrophic%' THEN 'Atrophic Changes'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%nuclear abnormality%' THEN 'Nuclear Abnormality'
-        ELSE 'Other Finding'
-    END AS abnormality_grade,
-
-    -- Sample adequacy type
-    CASE
-        WHEN obs.cluster_id != 'SMEAR_COD' THEN NULL
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%endocervical cells present%' THEN 'Adequate'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%inadequate%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%insufficient%' THEN 'Inadequate'
-        ELSE 'Unspecified'
-    END AS sample_adequacy,
-
-    -- Clinical action required
-    CASE
-        WHEN obs.cluster_id != 'SMEAR_COD' THEN NULL
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%action needed%'
-            OR LOWER(obs.mapped_concept_display) LIKE '%colposcopy%' THEN 'Colposcopy Required'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%repeat%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%follow%' THEN 'Repeat Required'
-        WHEN LOWER(obs.mapped_concept_display) LIKE '%normal%' 
-            OR LOWER(obs.mapped_concept_display) LIKE '%negative%' THEN 'Routine Follow-up'
-        ELSE 'Clinical Review'
-    END AS clinical_action_required
+    CASE WHEN obs.cluster_id = 'CSPCAINVITE_COD' THEN TRUE ELSE FALSE END AS is_non_response_screening
 
 FROM ({{ get_observations("'SMEAR_COD', 'CSPU_COD', 'CSDEC_COD', 'CSPCAINVITE_COD'") }}) obs
 WHERE obs.clinical_effective_date IS NOT NULL
 
-ORDER BY person_id, clinical_effective_date DESC, observation_id 
+ORDER BY person_id, clinical_effective_date DESC, observation_id

--- a/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_all.yml
+++ b/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_all.yml
@@ -1,10 +1,33 @@
 version: 2
 models:
   - name: int_cervical_screening_all
-    description: 'NHS cervical screening programme observations with cytology result interpretation and clinical risk assessment.
+    description: 'NHS cervical screening programme observations from clinical records.
 
-      One row per cervical screening observation using SMEAR_COD, CSPU_COD, CSDEC_COD, and CSPCAINVITE_COD clusters with cytology result categorisation and risk stratification.'
+      One row per cervical screening observation using SMEAR_COD, CSPU_COD, CSDEC_COD, and CSPCAINVITE_COD clusters for core programme tracking.'
     tests:
       - cluster_ids_exist:
           arguments:
             cluster_ids: SMEAR_COD,CSPU_COD,CSDEC_COD,CSPCAINVITE_COD
+    columns:
+      - name: observation_id
+        description: 'Unique identifier for the observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the screening observation was recorded'
+      - name: concept_code
+        description: 'Mapped clinical concept code'
+      - name: concept_display
+        description: 'Mapped clinical concept display text'
+      - name: source_cluster_id
+        description: 'QOF cluster identifier (SMEAR_COD, CSPU_COD, CSDEC_COD, CSPCAINVITE_COD)'
+      - name: screening_observation_type
+        description: 'Type of screening observation based on cluster'
+      - name: is_completed_screening
+        description: 'Flag indicating if this is a completed screening (SMEAR_COD)'
+      - name: is_unsuitable_screening
+        description: 'Flag indicating if person is unsuitable for screening (CSPU_COD)'
+      - name: is_declined_screening
+        description: 'Flag indicating if screening was declined (CSDEC_COD)'
+      - name: is_non_response_screening
+        description: 'Flag indicating non-response to invitations (CSPCAINVITE_COD)'

--- a/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_latest.sql
+++ b/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_latest.sql
@@ -28,12 +28,7 @@ SELECT
     is_completed_screening,
     is_unsuitable_screening,
     is_declined_screening,
-    is_non_response_screening,
-    cytology_result_category,
-    cervical_screening_risk_category,
-    abnormality_grade,
-    sample_adequacy,
-    clinical_action_required
+    is_non_response_screening
 
 FROM {{ ref('int_cervical_screening_all') }}
 
@@ -42,4 +37,4 @@ QUALIFY ROW_NUMBER() OVER (
     ORDER BY clinical_effective_date DESC, observation_id DESC
 ) = 1
 
-ORDER BY person_id 
+ORDER BY person_id

--- a/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_latest.yml
+++ b/models/olids/intermediate/programme/cervical_screening/int_cervical_screening_latest.yml
@@ -1,6 +1,29 @@
 version: 2
 models:
   - name: int_cervical_screening_latest
-    description: 'Most recent cervical screening status per person for current programme management.
+    description: 'Most recent cervical screening observation per person.
 
-      One row per person representing most recent cervical screening observation with cytology and risk information for programme coordination and clinical decision support.'
+      One row per person representing their latest cervical screening observation for programme tracking.'
+    columns:
+      - name: observation_id
+        description: 'Unique identifier for the observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date of the most recent screening observation'
+      - name: concept_code
+        description: 'Mapped clinical concept code'
+      - name: concept_display
+        description: 'Mapped clinical concept display text'
+      - name: source_cluster_id
+        description: 'QOF cluster identifier (SMEAR_COD, CSPU_COD, CSDEC_COD, CSPCAINVITE_COD)'
+      - name: screening_observation_type
+        description: 'Type of screening observation based on cluster'
+      - name: is_completed_screening
+        description: 'Flag indicating if latest observation is a completed screening'
+      - name: is_unsuitable_screening
+        description: 'Flag indicating if latest observation marks person as unsuitable'
+      - name: is_declined_screening
+        description: 'Flag indicating if latest observation is a declined screening'
+      - name: is_non_response_screening
+        description: 'Flag indicating if latest observation is non-response to invitations'

--- a/models/olids/intermediate/programme/flu/int_flu_person_week_snapshot.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_person_week_snapshot.sql
@@ -1,0 +1,179 @@
+/*
+Flu Person-Week Snapshot (Sparse)
+
+This model creates a sparse person-week table for flu vaccination tracking.
+Only stores "interesting" weeks where status changes occur or at boundaries.
+
+Key features:
+- Week 1 baseline for all eligible persons
+- Vaccination week when status changes
+- Final week (26) for complete comparison
+- Handles multiple campaigns automatically
+- ~2M rows instead of 156M for full person-week
+
+The sparse approach dramatically reduces storage while maintaining
+full analytical capability when expanded with window functions.
+*/
+
+{{ config(
+    materialized='incremental',
+    unique_key=['person_id', 'campaign_id', 'week_number'],
+    cluster_by=['campaign_id', 'week_number', 'person_id'],
+    on_schema_change='fail'
+) }}
+
+WITH campaign_configs AS (
+    -- Get all campaign configurations with effective dates
+    SELECT * FROM ({{ flu_campaign_config(var('flu_current_campaign', 'flu_2024_25')) }})
+    UNION ALL
+    SELECT * FROM ({{ flu_campaign_config(var('flu_previous_campaign', 'flu_2023_24')) }})
+),
+
+effective_dates AS (
+    -- Determine the effective end date for each campaign
+    SELECT 
+        campaign_id,
+        campaign_start_date,
+        campaign_end_date,
+        campaign_reference_date,
+        CASE 
+            WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+            WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+            ELSE CURRENT_DATE
+        END AS effective_end_date,
+        -- Calculate number of weeks in campaign (up to effective end, max 26 weeks)
+        LEAST(
+            DATEDIFF('week', campaign_start_date, 
+                LEAST(
+                    CASE 
+                        WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+                        WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+                        ELSE CURRENT_DATE
+                    END,
+                    campaign_reference_date
+                )
+            ) + 1,
+            26
+        ) AS max_week_number
+    FROM campaign_configs
+),
+
+-- Get all eligible persons per campaign
+eligible_persons AS (
+    SELECT DISTINCT 
+        e.campaign_id,
+        e.person_id,
+        -- Capture primary risk group for analysis
+        FIRST_VALUE(e.risk_group) OVER (
+            PARTITION BY e.campaign_id, e.person_id 
+            ORDER BY e.eligibility_priority
+        ) AS primary_risk_group,
+        ed.campaign_start_date,
+        ed.max_week_number
+    FROM {{ ref('fct_flu_eligibility') }} e
+    JOIN effective_dates ed ON e.campaign_id = ed.campaign_id
+),
+
+-- Get vaccination events with week numbers
+vaccination_events AS (
+    SELECT 
+        u.campaign_id,
+        u.person_id,
+        u.vaccination_date,
+        LEAST(DATEDIFF('week', ed.campaign_start_date, u.vaccination_date) + 1, 26) AS vaccination_week,
+        u.vaccination_status,
+        ed.max_week_number
+    FROM {{ ref('fct_flu_uptake') }} u
+    JOIN effective_dates ed ON u.campaign_id = ed.campaign_id
+    WHERE u.vaccinated = TRUE
+        AND u.vaccination_date >= ed.campaign_start_date
+        AND u.vaccination_date <= ed.effective_end_date
+        AND DATEDIFF('week', ed.campaign_start_date, u.vaccination_date) + 1 <= 26
+),
+
+-- Create sparse records
+sparse_records AS (
+    -- Week 1: Baseline for all eligible persons
+    SELECT 
+        campaign_id,
+        person_id,
+        1 AS week_number,
+        DATE_TRUNC('week', campaign_start_date) AS week_start_date,
+        'ELIGIBLE_NOT_VACCINATED' AS vaccination_status,
+        FALSE AS is_vaccinated,
+        primary_risk_group,
+        'baseline' AS record_type
+    FROM eligible_persons
+    WHERE 1 <= max_week_number  -- Only if campaign has started
+    
+    UNION ALL
+    
+    -- Vaccination week: Status change records
+    SELECT 
+        ve.campaign_id,
+        ve.person_id,
+        ve.vaccination_week AS week_number,
+        DATE_TRUNC('week', ve.vaccination_date) AS week_start_date,
+        ve.vaccination_status,
+        TRUE AS is_vaccinated,
+        ep.primary_risk_group,  -- Get risk group from eligible persons
+        'vaccination' AS record_type
+    FROM vaccination_events ve
+    JOIN eligible_persons ep ON ve.campaign_id = ep.campaign_id AND ve.person_id = ep.person_id
+    WHERE ve.vaccination_week BETWEEN 1 AND ve.max_week_number
+    
+    UNION ALL
+    
+    -- Final week: End state for all eligible persons (only if different from week 1)
+    SELECT 
+        ep.campaign_id,
+        ep.person_id,
+        LEAST(ep.max_week_number, 26) AS week_number,
+        DATEADD('week', LEAST(ep.max_week_number, 26) - 1, DATE_TRUNC('week', ep.campaign_start_date)) AS week_start_date,
+        COALESCE(ve.vaccination_status, 'ELIGIBLE_NOT_VACCINATED') AS vaccination_status,
+        CASE WHEN ve.person_id IS NOT NULL THEN TRUE ELSE FALSE END AS is_vaccinated,
+        ep.primary_risk_group,
+        'final' AS record_type
+    FROM eligible_persons ep
+    LEFT JOIN vaccination_events ve 
+        ON ep.campaign_id = ve.campaign_id 
+        AND ep.person_id = ve.person_id
+        AND ve.vaccination_week <= LEAST(ep.max_week_number, 26)
+    WHERE LEAST(ep.max_week_number, 26) > 1  -- Only if campaign has multiple weeks
+        AND LEAST(ep.max_week_number, 26) <= 26  -- Ensure within valid range
+)
+
+-- Final output with deduplication
+SELECT 
+    campaign_id,
+    person_id,
+    week_number,
+    week_start_date,
+    vaccination_status,
+    is_vaccinated,
+    COALESCE(
+        primary_risk_group,
+        FIRST_VALUE(primary_risk_group IGNORE NULLS) OVER (
+            PARTITION BY campaign_id, person_id 
+            ORDER BY week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        )
+    ) AS primary_risk_group,
+    record_type,
+    CURRENT_TIMESTAMP AS created_at
+FROM sparse_records
+
+{% if is_incremental() %}
+    -- Only process new weeks since last run
+    WHERE week_number > (
+        SELECT COALESCE(MAX(week_number), 0)
+        FROM {{ this }}
+        WHERE campaign_id = sparse_records.campaign_id
+    )
+{% endif %}
+
+-- Remove duplicates (keep most recent status for each person-week)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY campaign_id, person_id, week_number 
+    ORDER BY is_vaccinated DESC, record_type DESC
+) = 1

--- a/models/olids/intermediate/programme/flu/int_flu_person_week_snapshot.yml
+++ b/models/olids/intermediate/programme/flu/int_flu_person_week_snapshot.yml
@@ -1,0 +1,112 @@
+version: 2
+
+models:
+  - name: int_flu_person_week_snapshot
+    description: 'Sparse person-week snapshot for flu vaccination tracking.
+
+      This model dramatically reduces storage requirements by only storing weeks where vaccination status changes occur, rather than maintaining a full person-week table.
+
+      Key Features:
+
+      • Only stores "interesting" weeks: baseline (week 1), vaccination events, and final week
+
+      • Supports multiple campaigns automatically via flu_campaign_config macro
+
+      • Handles campaign end dates correctly using effective_end_date logic
+
+      • ~2M rows instead of 156M for full person-week approach (98% storage reduction)
+
+      • Optimised for expansion via window functions in downstream models
+
+      Technical Implementation:
+
+      • Incremental materialisation for efficient updates during campaigns
+
+      • Clustered by campaign_id, week_number, person_id for optimal query performance
+
+      • Uses sparse storage pattern: baseline + events + final state
+
+      • Deduplicates records to ensure data quality
+
+      The sparse approach enables complete analytical capability while maintaining excellent performance and minimal storage overhead.'
+
+    columns:
+      - name: campaign_id
+        description: 'Flu campaign identifier (e.g., flu_2024_25, flu_2023_24)'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['flu_2023_24', 'flu_2024_25', 'flu_2025_26']
+
+      - name: person_id
+        description: 'Unique person identifier'
+        tests:
+          - not_null
+
+      - name: week_number
+        description: 'Week number within campaign (1-26, starting from September)'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 26
+
+      - name: week_start_date
+        description: 'Start date of the week (Monday)'
+        tests:
+          - not_null
+
+      - name: vaccination_status
+        description: 'Vaccination status for this person-week'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['ELIGIBLE_NOT_VACCINATED', 'VACCINATION_ADMINISTERED', 'LAIV_ADMINISTERED', 'VACCINATION_DECLINED']
+
+      - name: is_vaccinated
+        description: 'Boolean flag indicating if person is vaccinated at this point'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: primary_risk_group
+        description: 'Primary risk group for eligibility (highest priority)'
+        tests:
+          - not_null
+
+      - name: record_type
+        description: 'Type of sparse record: baseline, vaccination, or final'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['baseline', 'vaccination', 'final']
+
+      - name: created_at
+        description: 'Timestamp when record was created'
+        tests:
+          - not_null
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - campaign_id
+              - person_id
+              - week_number
+          name: int_flu_person_week_snapshot_unique_person_week
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "vaccination_status = 'ELIGIBLE_NOT_VACCINATED' OR is_vaccinated = true"
+          name: int_flu_person_week_snapshot_vaccination_status_consistency
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "record_type IN ('baseline', 'vaccination', 'final')"
+          name: int_flu_person_week_snapshot_valid_record_types

--- a/models/olids/marts/programme/cervical_screening/fct_cervical_screening_status.sql
+++ b/models/olids/marts/programme/cervical_screening/fct_cervical_screening_status.sql
@@ -5,7 +5,7 @@
 
 /*
 Cervical Screening Programme Status - Person-Level Analytics
-Comprehensive cervical screening programme tracking with age-specific business rules.
+Simplified tracking focused on core programme monitoring requirements.
 
 Key Business Rules:
 1. Screening Intervals:
@@ -13,21 +13,16 @@ Key Business Rules:
    - Women aged 50-64: invited every 5 years
    - Women outside 25-64 age range: not eligible for routine screening
 
-2. Status Validity Rules:
-   - Completed screening (SMEAR_COD): Always valid for programme compliance
-   - Unsuitable status (CSPU_COD): Permanent until superseded by completed screening
-   - Declined/Non-response (CSDEC_COD/CSPCAINVITE_COD): Valid for 12 months only
-
-3. Programme Compliance:
+2. Programme Status:
    - Up to date: Completed screening within age-appropriate interval
-   - Overdue: Last screening outside age-appropriate interval but within programme history
-   - Never screened: No completed screening history within eligible age range
+   - Overdue: Last screening outside age-appropriate interval
+   - Never screened: No completed screening history
+   - Not eligible: Outside age range or not female
 
 Clinical Purpose:
-- Programme compliance monitoring and reporting
-- Risk stratification for population health management
+- Programme compliance monitoring
 - Screening interval tracking and invitation planning
-- Quality assurance and outcome monitoring
+- Population coverage reporting
 */
 
 WITH person_demographics AS (
@@ -87,7 +82,7 @@ screening_history AS (
     GROUP BY person_id
 ),
 
-current_status AS (
+programme_status AS (
     SELECT
         pd.person_id,
         pd.current_age,
@@ -100,12 +95,11 @@ current_status AS (
         cls.source_cluster_id AS latest_screening_type,
         cls.screening_observation_type,
         
-        -- Cytology results (from latest screening)
-        cls.cytology_result_category,
-        cls.cervical_screening_risk_category,
-        cls.abnormality_grade,
-        cls.sample_adequacy,
-        cls.clinical_action_required,
+        -- Core screening flags
+        cls.is_completed_screening AS latest_is_completed,
+        cls.is_unsuitable_screening AS latest_is_unsuitable,
+        cls.is_declined_screening AS latest_is_declined,
+        cls.is_non_response_screening AS latest_is_non_response,
         
         -- Screening history
         sh.latest_completed_date,
@@ -114,85 +108,43 @@ current_status AS (
         sh.total_declined_records,
         sh.total_non_response_records,
         
-        -- Time calculations
-        
-        
-        -- Status validity flags (business rules)
-        CASE
-            WHEN cls.source_cluster_id = 'SMEAR_COD' THEN TRUE  -- Completed screening always valid
-            WHEN cls.source_cluster_id = 'CSPU_COD' THEN TRUE   -- Unsuitable status permanent
-            WHEN cls.source_cluster_id IN ('CSDEC_COD', 'CSPCAINVITE_COD') 
-                AND DATEDIFF(day, cls.clinical_effective_date, CURRENT_DATE()) <= 365 THEN TRUE
-            ELSE FALSE
-        END AS is_current_status_valid,
-        
-        -- Current screening status determination
-        CASE
-            WHEN cls.is_completed_screening THEN 'Up to Date (Screened)'
-            WHEN cls.is_unsuitable_screening THEN 'Unsuitable for Screening'
-            WHEN cls.is_declined_screening 
-                AND DATEDIFF(day, cls.clinical_effective_date, CURRENT_DATE()) <= 365 THEN 'Recently Declined'
-            WHEN cls.is_non_response_screening 
-                AND DATEDIFF(day, cls.clinical_effective_date, CURRENT_DATE()) <= 365 THEN 'Non-responsive'
-            ELSE 'Status Expired'
-        END AS current_screening_status,
-        
         -- Never screened flag
         CASE
-            WHEN sh.total_completed_screenings = 0 THEN TRUE
+            WHEN sh.total_completed_screenings = 0 OR sh.total_completed_screenings IS NULL 
+            THEN TRUE
             ELSE FALSE
-        END AS never_screened
+        END AS never_screened,
+        
+        -- Programme compliance status (simplified)
+        CASE
+            WHEN NOT pd.is_screening_eligible THEN 'Not Eligible'
+            WHEN sh.total_completed_screenings = 0 OR sh.latest_completed_date IS NULL THEN 'Never Screened'
+            WHEN sh.latest_unsuitable_date IS NOT NULL 
+                AND (sh.latest_completed_date IS NULL OR sh.latest_unsuitable_date > sh.latest_completed_date)
+                THEN 'Unsuitable'
+            WHEN DATEDIFF(day, sh.latest_completed_date, CURRENT_DATE()) <= pd.screening_interval_days THEN 'Up to Date'
+            WHEN DATEDIFF(day, sh.latest_completed_date, CURRENT_DATE()) > pd.screening_interval_days THEN 'Overdue'
+            ELSE 'Unknown'
+        END AS programme_status,
+        
+        -- Next screening due calculation
+        CASE
+            WHEN sh.latest_completed_date IS NOT NULL AND pd.screening_interval_days IS NOT NULL
+            THEN DATEADD(day, pd.screening_interval_days, sh.latest_completed_date)
+            ELSE NULL
+        END AS next_screening_due_date,
+        
+        -- Days overdue calculation
+        CASE
+            WHEN sh.latest_completed_date IS NOT NULL AND pd.screening_interval_days IS NOT NULL
+                AND DATEDIFF(day, sh.latest_completed_date, CURRENT_DATE()) > pd.screening_interval_days
+            THEN DATEDIFF(day, sh.latest_completed_date, CURRENT_DATE()) - pd.screening_interval_days
+            ELSE NULL
+        END AS days_overdue
         
     FROM person_demographics pd
     LEFT JOIN {{ ref('int_cervical_screening_latest') }} cls ON pd.person_id = cls.person_id
     LEFT JOIN screening_history sh ON pd.person_id = sh.person_id
-),
-
-programme_compliance AS (
-    SELECT
-        cs.*,
-        
-        -- Programme compliance determination
-        CASE
-            WHEN NOT cs.is_screening_eligible THEN 'Not Eligible'
-            WHEN cs.never_screened OR cs.latest_completed_date IS NULL THEN 'Never Screened'
-            WHEN DATEDIFF(day, cs.latest_completed_date, CURRENT_DATE()) <= cs.screening_interval_days THEN 'Up to Date'
-            WHEN DATEDIFF(day, cs.latest_completed_date, CURRENT_DATE()) > cs.screening_interval_days THEN 'Overdue'
-            ELSE 'Unknown'
-        END AS programme_compliance_status,
-        
-        -- Risk flags based on abnormality grade
-        CASE
-            WHEN cs.abnormality_grade = 'High Grade' THEN TRUE
-            ELSE FALSE
-        END AS requires_urgent_follow_up,
-        
-        CASE
-            WHEN cs.clinical_action_required = 'Colposcopy Required' THEN TRUE
-            ELSE FALSE
-        END AS requires_colposcopy_referral,
-        
-        CASE
-            WHEN DATEDIFF(day, cs.latest_completed_date, CURRENT_DATE()) > cs.screening_interval_days
-                AND ROUND(DATEDIFF(day, cs.latest_completed_date, CURRENT_DATE()) / 365.25, 1) > 5 THEN TRUE
-            ELSE FALSE
-        END AS long_term_non_attendance,
-        
-        -- Next screening due calculation
-        CASE
-            WHEN cs.latest_completed_date IS NOT NULL AND cs.screening_interval_days IS NOT NULL
-            THEN DATEADD(day, cs.screening_interval_days, cs.latest_completed_date)
-            ELSE NULL
-        END AS next_screening_due_date,
-        
-        -- Overdue calculation
-        CASE
-            WHEN cs.latest_completed_date IS NOT NULL AND cs.screening_interval_days IS NOT NULL
-            THEN GREATEST(0, DATEDIFF(day, DATEADD(day, cs.screening_interval_days, cs.latest_completed_date), CURRENT_DATE()))
-            ELSE NULL
-        END AS days_overdue
-        
-    FROM current_status cs
 )
 
 SELECT
@@ -201,28 +153,22 @@ SELECT
     is_screening_eligible,
     screening_interval_years,
     
-    -- Programme compliance
-    programme_compliance_status,
-    current_screening_status,
+    -- Programme status
+    programme_status,
+    screening_observation_type AS latest_screening_type,
     
-    -- Latest screening information
+    -- Key dates
     latest_screening_date,
     latest_completed_date,
     next_screening_due_date,
     days_overdue,
     
-    -- Cytology results
-    cytology_result_category,
-    cervical_screening_risk_category,
-    abnormality_grade,
-    sample_adequacy,
-    clinical_action_required,
-    
-    -- Programme flags
+    -- Core flags
     never_screened,
-    requires_urgent_follow_up,
-    requires_colposcopy_referral,
-    long_term_non_attendance,
+    latest_is_completed,
+    latest_is_unsuitable,
+    latest_is_declined,
+    latest_is_non_response,
     
     -- Screening history counts
     total_completed_screenings,
@@ -230,7 +176,7 @@ SELECT
     total_declined_records,
     total_non_response_records
 
-FROM programme_compliance
+FROM programme_status
 WHERE is_screening_eligible = TRUE  -- Only include women eligible for screening
 
-ORDER BY person_id 
+ORDER BY person_id

--- a/models/olids/marts/programme/cervical_screening/fct_cervical_screening_status.yml
+++ b/models/olids/marts/programme/cervical_screening/fct_cervical_screening_status.yml
@@ -3,4 +3,46 @@ models:
   - name: fct_cervical_screening_status
     description: 'Cervical screening programme status for eligible females aged 25-64 years.
 
-      One row per eligible woman with age-specific intervals (3-year for 25-49, 5-year for 50-64), compliance status and risk stratification based on cytology results.'
+      Simplified person-level view focusing on core programme monitoring with screening intervals, compliance status and coverage metrics.'
+    columns:
+      - name: person_id
+        description: 'Unique identifier for the person'
+        tests:
+          - not_null
+          - unique
+      - name: current_age
+        description: 'Current age of the person in years'
+      - name: is_screening_eligible
+        description: 'Flag indicating if person is eligible for screening (Female, age 25-64)'
+      - name: screening_interval_years
+        description: 'Target screening interval in years based on age (3 years for 25-49, 5 years for 50-64)'
+      - name: programme_status
+        description: 'Overall programme compliance status (Up to Date, Overdue, Never Screened, Unsuitable, Not Eligible)'
+      - name: latest_screening_type
+        description: 'Type of the most recent screening observation'
+      - name: latest_screening_date
+        description: 'Date of the most recent screening observation'
+      - name: latest_completed_date
+        description: 'Date of the most recent completed screening (SMEAR_COD)'
+      - name: next_screening_due_date
+        description: 'Calculated next screening due date based on interval'
+      - name: days_overdue
+        description: 'Number of days overdue for screening (null if not overdue)'
+      - name: never_screened
+        description: 'Flag indicating person has never had a completed screening'
+      - name: latest_is_completed
+        description: 'Flag indicating if latest observation is a completed screening'
+      - name: latest_is_unsuitable
+        description: 'Flag indicating if latest observation marks person as unsuitable'
+      - name: latest_is_declined
+        description: 'Flag indicating if latest observation is a declined screening'
+      - name: latest_is_non_response
+        description: 'Flag indicating if latest observation is non-response to invitations'
+      - name: total_completed_screenings
+        description: 'Total count of completed screening observations'
+      - name: total_unsuitable_records
+        description: 'Total count of unsuitable status records'
+      - name: total_declined_records
+        description: 'Total count of declined screening records'
+      - name: total_non_response_records
+        description: 'Total count of non-response to invitation records'

--- a/models/olids/marts/programme/flu/fct_flu_weekly_org.sql
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_org.sql
@@ -1,0 +1,287 @@
+/*
+Flu Weekly Organisational Timeseries
+
+Practice-level weekly vaccination tracking that naturally supports
+organisational hierarchy rollups in PowerBI.
+
+Key features:
+- Practice grain with PCN, neighbourhood, and borough attributes
+- Weekly and cumulative vaccination counts
+- Eligible population counts per practice
+- Uptake rates calculated at practice level
+- PowerBI can aggregate up the hierarchy: Practice → PCN → Neighbourhood → Borough
+
+This table is optimised for organisational performance tracking and
+executive dashboards showing progress by geographical/administrative units.
+*/
+
+{{ config(
+    materialized='table',
+    cluster_by=['campaign_id', 'week_number', 'practice_code', 'risk_group']
+) }}
+
+WITH campaign_configs AS (
+    -- Get all campaign configurations
+    SELECT * FROM ({{ flu_campaign_config(var('flu_current_campaign', 'flu_2024_25')) }})
+    UNION ALL
+    SELECT * FROM ({{ flu_campaign_config(var('flu_previous_campaign', 'flu_2023_24')) }})
+),
+
+effective_dates AS (
+    -- Determine the effective end date for each campaign
+    SELECT 
+        campaign_id,
+        campaign_name,
+        campaign_start_date,
+        campaign_end_date,
+        campaign_reference_date,
+        CASE 
+            WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+            WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+            ELSE CURRENT_DATE
+        END AS effective_end_date,
+        -- Calculate max week number based on effective end
+        DATEDIFF('week', campaign_start_date, 
+            LEAST(
+                CASE 
+                    WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+                    WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+                    ELSE CURRENT_DATE
+                END,
+                campaign_reference_date
+            )
+        ) + 1 AS max_week_number
+    FROM campaign_configs
+),
+
+-- Generate week spine for each campaign
+week_spine AS (
+    SELECT 
+        ed.campaign_id,
+        ed.campaign_name,
+        seq.week_number,
+        DATEADD('week', seq.week_number - 1, DATE_TRUNC('week', ed.campaign_start_date)) AS week_start_date,
+        DATEADD('day', 6, DATEADD('week', seq.week_number - 1, DATE_TRUNC('week', ed.campaign_start_date))) AS week_end_date,
+        ed.campaign_start_date,
+        ed.effective_end_date,
+        ed.max_week_number
+    FROM effective_dates ed
+    CROSS JOIN (
+        SELECT ROW_NUMBER() OVER (ORDER BY seq4()) AS week_number
+        FROM TABLE(GENERATOR(ROWCOUNT => 26))
+    ) seq
+    WHERE seq.week_number <= ed.max_week_number
+),
+
+-- Get eligible counts by practice, risk group, and campaign category
+practice_eligible AS (
+    SELECT 
+        e.campaign_id,
+        d.practice_code,
+        e.risk_group,
+        e.campaign_category,
+        COUNT(DISTINCT e.person_id) AS eligible_count
+    FROM {{ ref('fct_flu_eligibility') }} e
+    JOIN {{ ref('dim_person_demographics') }} d ON e.person_id = d.person_id
+    WHERE d.is_active = TRUE
+    GROUP BY 1, 2, 3, 4
+),
+
+-- Get weekly vaccination counts by practice, risk group, and campaign category
+weekly_vaccinations AS (
+    SELECT 
+        u.campaign_id,
+        d.practice_code,
+        u.risk_group,
+        u.campaign_category,
+        DATEDIFF('week', cc.campaign_start_date, u.vaccination_date) + 1 AS week_number,
+        COUNT(DISTINCT u.person_id) AS weekly_vaccination_count
+    FROM {{ ref('fct_flu_uptake') }} u
+    JOIN {{ ref('dim_person_demographics') }} d ON u.person_id = d.person_id
+    JOIN campaign_configs cc ON u.campaign_id = cc.campaign_id
+    JOIN effective_dates ed ON u.campaign_id = ed.campaign_id
+    WHERE u.vaccinated = TRUE
+        AND u.vaccination_date >= cc.campaign_start_date
+        AND u.vaccination_date <= ed.effective_end_date
+        AND d.is_active = TRUE
+        AND u.risk_group IS NOT NULL  -- Ensure we have risk group info
+    GROUP BY 1, 2, 3, 4, 5
+),
+
+-- Combine all data with risk group and campaign category breakdowns
+practice_weekly AS (
+    SELECT 
+        ws.campaign_id,
+        ws.campaign_name,
+        ws.week_number,
+        ws.week_start_date,
+        ws.week_end_date,
+        pe.practice_code,
+        pe.risk_group,
+        pe.campaign_category,
+        pe.eligible_count,
+        COALESCE(wv.weekly_vaccination_count, 0) AS weekly_vaccination_count,
+        -- Calculate cumulative vaccinations by risk group
+        SUM(COALESCE(wv.weekly_vaccination_count, 0)) OVER (
+            PARTITION BY ws.campaign_id, pe.practice_code, pe.risk_group, pe.campaign_category
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS cumulative_vaccination_count
+    FROM week_spine ws
+    CROSS JOIN practice_eligible pe
+    LEFT JOIN weekly_vaccinations wv
+        ON ws.campaign_id = wv.campaign_id
+        AND pe.practice_code = wv.practice_code
+        AND pe.risk_group = wv.risk_group
+        AND pe.campaign_category = wv.campaign_category
+        AND ws.week_number = wv.week_number
+    WHERE pe.campaign_id = ws.campaign_id
+),
+
+-- Add total distinct counts per practice (to avoid double-counting overlapping risk groups)
+practice_totals AS (
+    SELECT 
+        e.campaign_id,
+        d.practice_code,
+        'Total' AS risk_group,
+        'All Categories' AS campaign_category,
+        COUNT(DISTINCT e.person_id) AS total_eligible_count
+    FROM {{ ref('fct_flu_eligibility') }} e
+    JOIN {{ ref('dim_person_demographics') }} d ON e.person_id = d.person_id
+    WHERE d.is_active = TRUE
+    GROUP BY 1, 2
+),
+
+weekly_vaccination_totals AS (
+    SELECT 
+        u.campaign_id,
+        d.practice_code,
+        'Total' AS risk_group,
+        'All Categories' AS campaign_category,
+        DATEDIFF('week', cc.campaign_start_date, u.vaccination_date) + 1 AS week_number,
+        COUNT(DISTINCT u.person_id) AS weekly_vaccination_count
+    FROM {{ ref('fct_flu_uptake') }} u
+    JOIN {{ ref('dim_person_demographics') }} d ON u.person_id = d.person_id
+    JOIN campaign_configs cc ON u.campaign_id = cc.campaign_id
+    JOIN effective_dates ed ON u.campaign_id = ed.campaign_id
+    WHERE u.vaccinated = TRUE
+        AND u.vaccination_date >= cc.campaign_start_date
+        AND u.vaccination_date <= ed.effective_end_date
+        AND d.is_active = TRUE
+    GROUP BY 1, 2, 3, 4, 5
+),
+
+practice_weekly_totals AS (
+    SELECT 
+        ws.campaign_id,
+        ws.campaign_name,
+        ws.week_number,
+        ws.week_start_date,
+        ws.week_end_date,
+        pt.practice_code,
+        pt.risk_group,
+        pt.campaign_category,
+        pt.total_eligible_count AS eligible_count,
+        COALESCE(wvt.weekly_vaccination_count, 0) AS weekly_vaccination_count,
+        -- Calculate cumulative vaccinations for totals
+        SUM(COALESCE(wvt.weekly_vaccination_count, 0)) OVER (
+            PARTITION BY ws.campaign_id, pt.practice_code
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS cumulative_vaccination_count
+    FROM week_spine ws
+    CROSS JOIN practice_totals pt
+    LEFT JOIN weekly_vaccination_totals wvt
+        ON ws.campaign_id = wvt.campaign_id
+        AND pt.practice_code = wvt.practice_code
+        AND ws.week_number = wvt.week_number
+    WHERE pt.campaign_id = ws.campaign_id
+),
+
+-- Combine risk group breakdowns with totals
+all_practice_weekly AS (
+    SELECT * FROM practice_weekly
+    UNION ALL
+    SELECT * FROM practice_weekly_totals
+),
+
+-- Add practice hierarchy information from demographics
+final_output AS (
+    SELECT 
+        pw.campaign_id,
+        pw.campaign_name,
+        pw.week_number,
+        pw.week_start_date,
+        pw.week_end_date,
+        
+        -- Practice level
+        pw.practice_code,
+        d.practice_name,
+        
+        -- Risk group and campaign category breakdowns
+        pw.risk_group,
+        pw.campaign_category,
+        
+        -- Organisational hierarchy (for PowerBI rollups)
+        d.pcn_code,
+        d.pcn_name,
+        d.practice_neighbourhood,
+        d.practice_borough,
+        d.practice_lsoa,
+        d.practice_msoa,
+        
+        -- Counts and rates
+        pw.eligible_count,
+        pw.weekly_vaccination_count,
+        pw.cumulative_vaccination_count,
+        
+        -- Calculate uptake rate
+        ROUND(
+            100.0 * pw.cumulative_vaccination_count / NULLIF(pw.eligible_count, 0), 
+            1
+        ) AS uptake_rate_percent,
+        
+        -- Week-over-week change (by risk group)
+        pw.cumulative_vaccination_count - LAG(pw.cumulative_vaccination_count, 1, 0) OVER (
+            PARTITION BY pw.campaign_id, pw.practice_code, pw.risk_group, pw.campaign_category
+            ORDER BY pw.week_number
+        ) AS week_on_week_change,
+        
+        -- Remaining to vaccinate
+        pw.eligible_count - pw.cumulative_vaccination_count AS remaining_eligible,
+        
+        -- Campaign progress indicators
+        CASE 
+            WHEN pw.week_number = 1 THEN 'Campaign Start'
+            WHEN pw.week_number BETWEEN 8 AND 12 THEN 'Peak Period'
+            WHEN pw.week_number > 20 THEN 'Campaign End'
+            ELSE 'Active Period'
+        END AS campaign_phase,
+        
+        -- Is this the latest week with data?
+        CASE 
+            WHEN pw.week_number = MAX(pw.week_number) OVER (PARTITION BY pw.campaign_id)
+            THEN TRUE ELSE FALSE 
+        END AS is_latest_week,
+        
+        CURRENT_TIMESTAMP AS created_at
+        
+    FROM all_practice_weekly pw
+    LEFT JOIN (
+        -- Get one representative row per practice for hierarchy info
+        SELECT DISTINCT
+            practice_code,
+            practice_name,
+            pcn_code,
+            pcn_name,
+            practice_neighbourhood,
+            practice_borough,
+            practice_lsoa,
+            practice_msoa
+        FROM {{ ref('dim_person_demographics') }}
+        WHERE is_active = TRUE
+    ) d ON pw.practice_code = d.practice_code
+)
+
+SELECT * FROM final_output
+ORDER BY campaign_id DESC, week_number, practice_borough, practice_neighbourhood, practice_code, campaign_category, risk_group

--- a/models/olids/marts/programme/flu/fct_flu_weekly_org.yml
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_org.yml
@@ -1,0 +1,196 @@
+version: 2
+
+models:
+  - name: fct_flu_weekly_org
+    description: 'Practice-level weekly flu vaccination tracking by risk group and campaign category.
+
+      This table provides detailed vaccination metrics broken down by practice, risk group, and campaign category, enabling comprehensive analysis while supporting organisational hierarchy rollups.
+
+      Key Features:
+
+      • Practice × Risk Group × Campaign Category grain with weekly and cumulative vaccination counts
+
+      • Includes both detailed risk group breakdowns AND practice totals to avoid double-counting
+
+      • Complete organisational hierarchy for natural PowerBI rollups
+
+      • Risk group analysis (Over 65, Diabetes, Clinical Conditions, etc.) plus "Total" rows
+
+      • Campaign category breakdowns (Age Based, Clinical Condition, At Risk Group) plus "All Categories"
+
+      • Handles overlapping risk groups correctly with distinct person counts in "Total" rows
+
+      • Handles campaign end dates using effective_end_date logic
+
+      • Optimised for detailed performance monitoring and risk group analysis
+
+      PowerBI Rollup Hierarchy:
+
+      • Practice Code → PCN → Practice Neighbourhood → Practice Borough
+
+      • All geographical attributes pre-joined for immediate use
+
+      • Supports drill-down and roll-up analysis without additional joins
+
+      Use Cases:
+
+      • Executive dashboards showing borough-level performance
+
+      • Practice manager views of individual practice progress
+
+      • PCN-level coordination and comparison
+
+      • Weekly operational reporting during flu campaigns'
+
+    columns:
+      - name: campaign_id
+        description: 'Flu campaign identifier'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['flu_2023_24', 'flu_2024_25', 'flu_2025_26']
+
+      - name: campaign_name
+        description: 'Human-readable campaign name'
+        tests:
+          - not_null
+
+      - name: week_number
+        description: 'Week number within campaign (1-26)'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 26
+
+      - name: week_start_date
+        description: 'Start date of the week (Monday)'
+        tests:
+          - not_null
+
+      - name: week_end_date
+        description: 'End date of the week (Sunday)'
+        tests:
+          - not_null
+
+      - name: practice_code
+        description: 'GP practice code'
+        tests:
+          - not_null
+
+      - name: practice_name
+        description: 'GP practice name'
+        tests:
+          - not_null
+
+      - name: risk_group
+        description: 'Specific risk group for eligibility (e.g., Over 65, Diabetes, etc.) or "Total" for practice-level distinct counts'
+        tests:
+          - not_null
+
+      - name: campaign_category
+        description: 'High-level eligibility category (e.g., Age Based, Clinical Condition) or "All Categories" for practice totals'
+        tests:
+          - not_null
+
+      - name: pcn_code
+        description: 'Primary Care Network code'
+
+      - name: pcn_name
+        description: 'Primary Care Network name'
+
+      - name: practice_neighbourhood
+        description: 'Practice neighbourhood for geographical grouping'
+
+      - name: practice_borough
+        description: 'Practice borough for top-level geographical grouping'
+
+      - name: eligible_count
+        description: 'Number of eligible persons at this practice'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: weekly_vaccination_count
+        description: 'Number of vaccinations administered this specific week'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: cumulative_vaccination_count
+        description: 'Total vaccinations administered up to and including this week'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: uptake_rate_percent
+        description: 'Vaccination uptake rate as percentage (cumulative vaccinations / eligible)'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 100
+
+      - name: week_on_week_change
+        description: 'Change in cumulative vaccinations from previous week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: remaining_eligible
+        description: 'Number of eligible persons not yet vaccinated'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: campaign_phase
+        description: 'Phase of campaign based on week number'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Campaign Start', 'Active Period', 'Peak Period', 'Campaign End']
+
+      - name: is_latest_week
+        description: 'Boolean flag indicating if this is the latest week with data'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - campaign_id
+              - week_number
+              - practice_code
+              - risk_group
+              - campaign_category
+          name: fct_flu_weekly_org_unique_campaign_week_practice_risk
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "cumulative_vaccination_count <= eligible_count"
+          name: fct_flu_weekly_org_cumulative_not_exceeds_eligible
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "weekly_vaccination_count <= cumulative_vaccination_count"
+          name: fct_flu_weekly_org_weekly_not_exceeds_cumulative
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "week_end_date = DATEADD('day', 6, week_start_date)"
+          name: fct_flu_weekly_org_valid_week_range

--- a/models/olids/marts/programme/flu/fct_flu_weekly_person.sql
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_person.sql
@@ -1,0 +1,234 @@
+/*
+Flu Weekly Person-Level Timeseries
+
+Expands the sparse person-week snapshot to provide complete weekly status
+for every eligible person, supporting complex multi-dimensional filtering in PowerBI.
+
+Key features:
+- Complete person × week × campaign grain
+- All demographic and risk group dimensions included
+- Vaccination status carried forward using window functions
+- Optimised for PowerBI filtering by any combination of attributes
+- Supports complex queries like "diabetic AND over 65 AND high deprivation"
+
+This table enables rich analytical capability while being efficient through
+the sparse source and targeted materialisation.
+*/
+
+{{ config(
+    materialized='table',
+    cluster_by=['campaign_id', 'week_number', 'practice_code'],
+    pre_hook="DROP TABLE IF EXISTS {{ this }}_temp"
+) }}
+
+WITH campaign_configs AS (
+    -- Get all campaign configurations
+    SELECT * FROM ({{ flu_campaign_config(var('flu_current_campaign', 'flu_2024_25')) }})
+    UNION ALL
+    SELECT * FROM ({{ flu_campaign_config(var('flu_previous_campaign', 'flu_2023_24')) }})
+),
+
+effective_dates AS (
+    -- Determine effective end date for each campaign
+    SELECT 
+        campaign_id,
+        campaign_name,
+        campaign_start_date,
+        CASE 
+            WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+            WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+            ELSE CURRENT_DATE
+        END AS effective_end_date,
+        DATEDIFF('week', campaign_start_date, 
+            LEAST(
+                CASE 
+                    WHEN CURRENT_DATE > campaign_reference_date THEN campaign_reference_date
+                    WHEN CURRENT_DATE > campaign_end_date THEN campaign_end_date
+                    ELSE CURRENT_DATE
+                END,
+                campaign_reference_date
+            )
+        ) + 1 AS max_week_number
+    FROM campaign_configs
+),
+
+-- Generate complete week spine for each eligible person
+person_week_spine AS (
+    SELECT 
+        e.campaign_id,
+        e.person_id,
+        seq.week_number,
+        DATEADD('week', seq.week_number - 1, DATE_TRUNC('week', ed.campaign_start_date)) AS week_start_date,
+        ed.campaign_name,
+        ed.max_week_number
+    FROM {{ ref('fct_flu_eligibility') }} e
+    JOIN effective_dates ed ON e.campaign_id = ed.campaign_id
+    CROSS JOIN (
+        SELECT ROW_NUMBER() OVER (ORDER BY seq4()) AS week_number
+        FROM TABLE(GENERATOR(ROWCOUNT => 26))
+    ) seq
+    WHERE seq.week_number <= ed.max_week_number
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY e.campaign_id, e.person_id ORDER BY e.eligibility_priority) = 1
+),
+
+-- Get sparse snapshot data
+sparse_data AS (
+    SELECT 
+        campaign_id,
+        person_id,
+        week_number,
+        vaccination_status,
+        is_vaccinated,
+        primary_risk_group
+    FROM {{ ref('int_flu_person_week_snapshot') }}
+),
+
+-- Expand sparse data to complete timeline
+expanded_timeline AS (
+    SELECT 
+        pws.campaign_id,
+        pws.campaign_name,
+        pws.person_id,
+        pws.week_number,
+        pws.week_start_date,
+        
+        -- Carry forward vaccination status using window function
+        LAST_VALUE(sd.vaccination_status IGNORE NULLS) OVER (
+            PARTITION BY pws.campaign_id, pws.person_id
+            ORDER BY pws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS current_vaccination_status,
+        
+        -- Carry forward vaccination flag
+        LAST_VALUE(sd.is_vaccinated IGNORE NULLS) OVER (
+            PARTITION BY pws.campaign_id, pws.person_id
+            ORDER BY pws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS is_currently_vaccinated,
+        
+        -- Determine if this was the week of vaccination
+        CASE 
+            WHEN sd.is_vaccinated = TRUE AND sd.week_number = pws.week_number 
+            THEN TRUE ELSE FALSE 
+        END AS vaccination_occurred_this_week,
+        
+        -- Get primary risk group from eligibility (filled later)
+        sd.primary_risk_group
+        
+    FROM person_week_spine pws
+    LEFT JOIN sparse_data sd
+        ON pws.campaign_id = sd.campaign_id
+        AND pws.person_id = sd.person_id
+        AND pws.week_number = sd.week_number
+),
+
+-- Add comprehensive demographics and risk groups
+final_with_demographics AS (
+    SELECT 
+        et.campaign_id,
+        et.campaign_name,
+        et.person_id,
+        et.week_number,
+        et.week_start_date,
+        
+        -- Vaccination status
+        COALESCE(et.current_vaccination_status, 'ELIGIBLE_NOT_VACCINATED') AS vaccination_status,
+        COALESCE(et.is_currently_vaccinated, FALSE) AS is_vaccinated,
+        et.vaccination_occurred_this_week,
+        
+        -- Fill primary risk group from eligibility
+        COALESCE(
+            et.primary_risk_group,
+            ef.risk_group,
+            'Unknown'
+        ) AS primary_risk_group,
+        
+        -- Demographics (current snapshot for efficiency)
+        d.sex,
+        d.age,
+        d.age_band_5y,
+        d.age_band_10y,
+        d.age_band_nhs,
+        d.age_life_stage,
+        d.ethnicity_category,
+        d.ethnicity_subcategory,
+        d.main_language,
+        d.interpreter_needed,
+        
+        -- Geography and organisation
+        d.practice_code,
+        d.practice_name,
+        d.pcn_code,
+        d.pcn_name,
+        d.practice_borough,
+        d.practice_neighbourhood,
+        d.lsoa_code_21,
+        d.ward_name,
+        d.imd_decile_19,
+        d.imd_quintile_19,
+        
+        -- Risk group flags (for complex filtering)
+        CASE WHEN ef.campaign_category = 'Age Based' THEN TRUE ELSE FALSE END AS is_age_eligible,
+        CASE WHEN ef.campaign_category = 'Clinical Condition' THEN TRUE ELSE FALSE END AS is_clinical_eligible,
+        CASE WHEN ef.campaign_category = 'At Risk Group' THEN TRUE ELSE FALSE END AS is_at_risk_eligible,
+        
+        -- Individual risk group flags for filtering
+        CASE WHEN ef.risk_group = 'Over 65' THEN TRUE ELSE FALSE END AS is_over_65,
+        CASE WHEN ef.risk_group = 'Children Preschool' THEN TRUE ELSE FALSE END AS is_preschool,
+        CASE WHEN ef.risk_group = 'Children School Age' THEN TRUE ELSE FALSE END AS is_school_age,
+        CASE WHEN ef.risk_group = 'Diabetes' THEN TRUE ELSE FALSE END AS has_diabetes,
+        CASE WHEN ef.risk_group = 'Chronic Heart Disease' THEN TRUE ELSE FALSE END AS has_heart_disease,
+        CASE WHEN ef.risk_group = 'Chronic Respiratory Disease' THEN TRUE ELSE FALSE END AS has_respiratory_disease,
+        CASE WHEN ef.risk_group = 'Chronic Kidney Disease' THEN TRUE ELSE FALSE END AS has_kidney_disease,
+        CASE WHEN ef.risk_group = 'Chronic Liver Disease' THEN TRUE ELSE FALSE END AS has_liver_disease,
+        CASE WHEN ef.risk_group = 'Chronic Neurological Disease' THEN TRUE ELSE FALSE END AS has_neurological_disease,
+        CASE WHEN ef.risk_group = 'Immunosuppression' THEN TRUE ELSE FALSE END AS has_immunosuppression,
+        CASE WHEN ef.risk_group = 'Asplenia' THEN TRUE ELSE FALSE END AS has_asplenia,
+        CASE WHEN ef.risk_group = 'Pregnancy' THEN TRUE ELSE FALSE END AS is_pregnant,
+        CASE WHEN ef.risk_group = 'Severe Obesity' THEN TRUE ELSE FALSE END AS has_severe_obesity,
+        CASE WHEN ef.risk_group = 'Learning Disability' THEN TRUE ELSE FALSE END AS has_learning_disability,
+        CASE WHEN ef.risk_group = 'Unpaid Carer' THEN TRUE ELSE FALSE END AS is_unpaid_carer,
+        CASE WHEN ef.risk_group = 'Health Social Care Worker' THEN TRUE ELSE FALSE END AS is_health_worker,
+        CASE WHEN ef.risk_group = 'Long Term Residential Care' THEN TRUE ELSE FALSE END AS in_residential_care,
+        CASE WHEN ef.risk_group = 'Homeless' THEN TRUE ELSE FALSE END AS is_homeless,
+        CASE WHEN ef.risk_group = 'Household Immunocompromised' THEN TRUE ELSE FALSE END AS household_immunocompromised,
+        
+        -- Weekly position metrics
+        DATEDIFF('day', et.week_start_date, CURRENT_DATE) AS days_since_week_start,
+        CASE 
+            WHEN et.week_number BETWEEN 1 AND 4 THEN 'Early Campaign'
+            WHEN et.week_number BETWEEN 5 AND 12 THEN 'Peak Campaign'
+            WHEN et.week_number BETWEEN 13 AND 20 THEN 'Late Campaign'
+            ELSE 'End Campaign'
+        END AS campaign_phase,
+        
+        -- Is this the current/latest week with data?
+        CASE 
+            WHEN et.week_number = MAX(et.week_number) OVER (PARTITION BY et.campaign_id)
+            THEN TRUE ELSE FALSE 
+        END AS is_latest_week,
+        
+        CURRENT_TIMESTAMP AS created_at
+        
+    FROM expanded_timeline et
+    -- Join demographics once
+    JOIN {{ ref('dim_person_demographics') }} d 
+        ON et.person_id = d.person_id
+    -- Join eligibility for risk group flags
+    LEFT JOIN {{ ref('fct_flu_eligibility') }} ef
+        ON et.campaign_id = ef.campaign_id
+        AND et.person_id = ef.person_id
+        AND et.primary_risk_group = ef.risk_group
+    
+    WHERE d.is_active = TRUE
+        AND d.age BETWEEN 0 AND 120  -- Filter out invalid ages
+    
+    -- Deduplicate in case of multiple eligibility records
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY et.campaign_id, et.person_id, et.week_number 
+        ORDER BY ef.eligibility_priority NULLS LAST
+    ) = 1
+)
+
+SELECT * FROM final_with_demographics
+ORDER BY campaign_id DESC, week_number, practice_code, person_id

--- a/models/olids/marts/programme/flu/fct_flu_weekly_person.yml
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_person.yml
@@ -1,0 +1,254 @@
+version: 2
+
+models:
+  - name: fct_flu_weekly_person
+    description: 'Person-level weekly flu vaccination timeseries supporting complex multi-dimensional filtering.
+
+      This table expands the sparse person-week snapshot to provide complete weekly vaccination status for every eligible person, enabling sophisticated PowerBI analysis with any combination of demographic and risk group filters.
+
+      Key Features:
+
+      • Complete person × week × campaign grain with carried-forward vaccination status
+
+      • All demographic dimensions included for complex filtering
+
+      • Individual risk group flags for PowerBI filter combinations
+
+      • Optimised for queries like "diabetic AND over 65 AND high deprivation"
+
+      • Built efficiently from sparse source data using window functions
+
+      PowerBI Use Cases:
+
+      • Multi-dimensional analysis: "Show uptake for diabetic patients over 65 in Tower Hamlets"
+
+      • Risk group combinations: "Compare uptake between single vs multiple risk groups"
+
+      • Demographic segmentation: "Analyse uptake by ethnicity within each age band"
+
+      • Geographic drill-down: "Practice performance for specific patient cohorts"
+
+      Technical Implementation:
+
+      • Expands ~2M sparse records to complete timeline using window functions
+
+      • Clusters by campaign_id, week_number, practice_code for optimal filtering performance
+
+      • Pre-joins demographics to avoid complex joins in PowerBI
+
+      • Handles campaign end dates correctly with effective_end_date logic'
+
+    columns:
+      - name: campaign_id
+        description: 'Flu campaign identifier'
+        tests:
+          - not_null
+
+      - name: campaign_name
+        description: 'Human-readable campaign name'
+        tests:
+          - not_null
+
+      - name: person_id
+        description: 'Unique person identifier'
+        tests:
+          - not_null
+
+      - name: week_number
+        description: 'Week number within campaign (1-26)'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 26
+
+      - name: week_start_date
+        description: 'Start date of the week (Monday)'
+        tests:
+          - not_null
+
+      - name: vaccination_status
+        description: 'Current vaccination status (carried forward from last change)'
+        tests:
+          - not_null
+
+      - name: is_vaccinated
+        description: 'Boolean flag indicating current vaccination status'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: vaccination_occurred_this_week
+        description: 'Boolean flag indicating if vaccination occurred this specific week'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: primary_risk_group
+        description: 'Primary eligibility risk group'
+        tests:
+          - not_null
+
+      # Demographics
+      - name: sex
+        description: 'Person sex'
+        tests:
+          - not_null
+
+      - name: age
+        description: 'Person age at campaign reference date'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 120
+
+      - name: age_band_5y
+        description: '5-year age bands for analysis'
+
+      - name: age_band_10y
+        description: '10-year age bands for analysis'
+
+      - name: ethnicity_category
+        description: 'High-level ethnicity category'
+        tests:
+          - not_null
+
+      - name: main_language
+        description: 'Person main language'
+
+      - name: interpreter_needed
+        description: 'Boolean flag for interpreter requirement'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      # Geography and Organisation
+      - name: practice_code
+        description: 'GP practice code'
+        tests:
+          - not_null
+
+      - name: practice_borough
+        description: 'Practice borough'
+
+      - name: lsoa_code_21
+        description: 'Lower Super Output Area code (2021)'
+
+      - name: imd_decile_19
+        description: 'Index of Multiple Deprivation decile (2019)'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 10
+
+      # Risk Group Flags for PowerBI filtering
+      - name: is_age_eligible
+        description: 'Eligible based on age criteria'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_clinical_eligible
+        description: 'Eligible based on clinical conditions'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_over_65
+        description: 'Person is over 65 years old'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: has_diabetes
+        description: 'Person has diabetes or Addisons disease'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: has_heart_disease
+        description: 'Person has chronic heart disease'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: has_respiratory_disease
+        description: 'Person has chronic respiratory disease'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: has_immunosuppression
+        description: 'Person has immunosuppression'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_pregnant
+        description: 'Person is pregnant'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: has_learning_disability
+        description: 'Person has learning disability'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_health_worker
+        description: 'Person is health or social care worker'
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: campaign_phase
+        description: 'Phase of campaign based on week number'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Early Campaign', 'Peak Campaign', 'Late Campaign', 'End Campaign']
+
+      - name: is_latest_week
+        description: 'Boolean flag indicating if this is the latest week with data'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - campaign_id
+              - person_id
+              - week_number
+          name: fct_flu_weekly_person_unique_person_week
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "NOT (vaccination_occurred_this_week = true AND is_vaccinated = false)"
+          name: fct_flu_weekly_person_vaccination_logic_consistency

--- a/models/olids/marts/programme/flu/flu_weekly_comparison.sql
+++ b/models/olids/marts/programme/flu/flu_weekly_comparison.sql
@@ -1,0 +1,234 @@
+/*
+Flu Weekly Campaign Comparison View
+
+Provides side-by-side comparison of current vs previous flu campaign
+at equivalent time points, handling campaign end dates correctly.
+
+Key features:
+- Week-aligned comparison (Week 1 vs Week 1, etc.)
+- Shows "ahead or behind" metrics
+- Handles incomplete current season vs complete previous season
+- Supports both organisational and person-level comparisons
+- Automatically adjusts based on campaign status (active vs ended)
+
+This view enables answering the key question: "Are we ahead of or behind
+where we were at this point last year?"
+*/
+
+{{ config(
+    materialized='view'
+) }}
+
+WITH campaign_status AS (
+    -- Determine current campaign status
+    SELECT 
+        cc.campaign_id,
+        cc.campaign_name,
+        cc.campaign_start_date,
+        cc.campaign_end_date,
+        cc.campaign_reference_date,
+        CASE 
+            WHEN CURRENT_DATE > cc.campaign_reference_date THEN 'COMPLETED'
+            WHEN CURRENT_DATE > cc.campaign_end_date THEN 'COMPLETED'
+            WHEN CURRENT_DATE >= cc.campaign_start_date THEN 'ACTIVE'
+            ELSE 'FUTURE'
+        END AS campaign_status,
+        CASE 
+            WHEN CURRENT_DATE > cc.campaign_reference_date THEN cc.campaign_reference_date
+            WHEN CURRENT_DATE > cc.campaign_end_date THEN cc.campaign_end_date
+            ELSE CURRENT_DATE
+        END AS effective_comparison_date,
+        LEAST(
+            DATEDIFF('week', cc.campaign_start_date, 
+                CASE 
+                    WHEN CURRENT_DATE > cc.campaign_reference_date THEN cc.campaign_reference_date
+                    WHEN CURRENT_DATE > cc.campaign_end_date THEN cc.campaign_end_date
+                    ELSE CURRENT_DATE
+                END
+            ) + 1,
+            26
+        ) AS current_week_position
+    FROM ({{ flu_campaign_config(var('flu_current_campaign', 'flu_2024_25')) }}) cc
+    
+    UNION ALL
+    
+    SELECT 
+        cc.campaign_id,
+        cc.campaign_name,
+        cc.campaign_start_date,
+        cc.campaign_end_date,
+        cc.campaign_reference_date,
+        'HISTORICAL' AS campaign_status,
+        cc.campaign_reference_date AS effective_comparison_date,
+        LEAST(DATEDIFF('week', cc.campaign_start_date, cc.campaign_reference_date) + 1, 26) AS current_week_position
+    FROM ({{ flu_campaign_config(var('flu_previous_campaign', 'flu_2023_24')) }}) cc
+),
+
+-- Get current campaign data (with risk group breakdown)
+current_campaign AS (
+    SELECT 
+        org.week_number,
+        org.week_start_date,
+        org.practice_code,
+        org.practice_name,
+        org.pcn_name,
+        org.practice_neighbourhood,
+        org.practice_borough,
+        org.risk_group,
+        org.campaign_category,
+        org.eligible_count,
+        org.cumulative_vaccination_count,
+        org.uptake_rate_percent,
+        org.weekly_vaccination_count,
+        cs.campaign_status,
+        cs.current_week_position,
+        cs.effective_comparison_date
+    FROM {{ ref('fct_flu_weekly_org') }} org
+    JOIN campaign_status cs 
+        ON org.campaign_id = cs.campaign_id
+    WHERE org.campaign_id = '{{ var('flu_current_campaign', 'flu_2024_25') }}'
+),
+
+-- Get previous campaign data (with risk group breakdown)
+previous_campaign AS (
+    SELECT 
+        org.week_number,
+        org.practice_code,
+        org.risk_group,
+        org.campaign_category,
+        org.eligible_count AS prev_eligible_count,
+        org.cumulative_vaccination_count AS prev_cumulative_vaccination_count,
+        org.uptake_rate_percent AS prev_uptake_rate_percent,
+        org.weekly_vaccination_count AS prev_weekly_vaccination_count
+    FROM {{ ref('fct_flu_weekly_org') }} org
+    WHERE org.campaign_id = '{{ var('flu_previous_campaign', 'flu_2023_24') }}'
+),
+
+-- Combine current and previous data
+combined_comparison AS (
+    SELECT 
+        curr.week_number,
+        curr.week_start_date,
+        
+        -- Practice hierarchy (smallest to largest unit)
+        curr.practice_code,
+        curr.practice_name,
+        curr.pcn_name,
+        curr.practice_neighbourhood,
+        curr.practice_borough,
+        
+        -- Risk group dimensions
+        curr.risk_group,
+        curr.campaign_category,
+        
+        -- Current campaign metrics
+        curr.eligible_count AS current_eligible,
+        curr.cumulative_vaccination_count AS current_cumulative_vaccinations,
+        curr.uptake_rate_percent AS current_uptake_rate,
+        curr.weekly_vaccination_count AS current_weekly_vaccinations,
+        
+        -- Previous season metrics (same week position, previous campaign)
+        prev.prev_eligible_count AS previous_season_eligible,
+        prev.prev_cumulative_vaccination_count AS previous_season_cumulative_vaccinations,
+        prev.prev_uptake_rate_percent AS previous_season_uptake_rate,
+        prev.prev_weekly_vaccination_count AS previous_season_weekly_vaccinations,
+        
+        -- Year-over-year comparison metrics (current season vs previous season)
+        curr.cumulative_vaccination_count - prev.prev_cumulative_vaccination_count AS vaccinations_vs_previous_season,
+        curr.uptake_rate_percent - prev.prev_uptake_rate_percent AS uptake_rate_difference_vs_previous_season,
+        
+        -- Year-over-year percentage change
+        CASE 
+            WHEN prev.prev_cumulative_vaccination_count > 0
+            THEN ROUND(
+                100.0 * (curr.cumulative_vaccination_count - prev.prev_cumulative_vaccination_count) 
+                / prev.prev_cumulative_vaccination_count, 
+                1
+            )
+            ELSE NULL
+        END AS percentage_change_vs_previous_season,
+        
+        -- Year-over-year performance indicators
+        CASE 
+            WHEN curr.cumulative_vaccination_count > prev.prev_cumulative_vaccination_count THEN 'AHEAD'
+            WHEN curr.cumulative_vaccination_count < prev.prev_cumulative_vaccination_count THEN 'BEHIND'
+            ELSE 'EQUAL'
+        END AS position_vs_previous_season,
+        
+        CASE 
+            WHEN curr.uptake_rate_percent > prev.prev_uptake_rate_percent THEN 'HIGHER'
+            WHEN curr.uptake_rate_percent < prev.prev_uptake_rate_percent THEN 'LOWER'
+            ELSE 'EQUAL'
+        END AS uptake_rate_vs_previous_season,
+        
+        -- Campaign context
+        curr.campaign_status,
+        curr.current_week_position,
+        curr.effective_comparison_date,
+        
+        -- Comparison validity
+        CASE 
+            WHEN curr.campaign_status = 'COMPLETED' THEN 'Final vs Final'
+            WHEN curr.week_number <= curr.current_week_position THEN 'Week ' || curr.week_number || ' Comparison'
+            ELSE 'Future Week - No Data'
+        END AS comparison_type,
+        
+        -- Trajectory indicators (for incomplete current campaign)
+        CASE 
+            WHEN curr.campaign_status = 'ACTIVE' AND curr.week_number = curr.current_week_position
+            THEN CASE 
+                WHEN curr.cumulative_vaccination_count > prev.prev_cumulative_vaccination_count * 1.05 THEN 'Strong'
+                WHEN curr.cumulative_vaccination_count > prev.prev_cumulative_vaccination_count THEN 'Good'
+                WHEN curr.cumulative_vaccination_count > prev.prev_cumulative_vaccination_count * 0.95 THEN 'On Track'
+                ELSE 'Concerning'
+            END
+            ELSE NULL
+        END AS current_trajectory,
+        
+        CURRENT_TIMESTAMP AS created_at
+        
+    FROM current_campaign curr
+    LEFT JOIN previous_campaign prev
+        ON curr.week_number = prev.week_number
+        AND curr.practice_code = prev.practice_code
+        AND curr.risk_group = prev.risk_group
+        AND curr.campaign_category = prev.campaign_category
+),
+
+-- Add summary statistics
+practice_summary AS (
+    SELECT 
+        *,
+        -- Week-specific rankings
+        RANK() OVER (
+            PARTITION BY week_number 
+            ORDER BY current_cumulative_vaccinations DESC
+        ) AS practice_rank_current_week,
+        
+        RANK() OVER (
+            PARTITION BY week_number 
+            ORDER BY vaccinations_vs_previous_season DESC
+        ) AS practice_rank_vs_previous_season,
+        
+        -- PCN and Borough aggregations for context
+        SUM(current_cumulative_vaccinations) OVER (
+            PARTITION BY week_number, pcn_name
+        ) AS pcn_total_current,
+        
+        SUM(previous_season_cumulative_vaccinations) OVER (
+            PARTITION BY week_number, pcn_name
+        ) AS pcn_total_previous_season,
+        
+        SUM(current_cumulative_vaccinations) OVER (
+            PARTITION BY week_number, practice_borough
+        ) AS borough_total_current,
+        
+        SUM(previous_season_cumulative_vaccinations) OVER (
+            PARTITION BY week_number, practice_borough
+        ) AS borough_total_previous_season
+        
+    FROM combined_comparison
+)
+
+SELECT * FROM practice_summary
+ORDER BY week_number ASC, practice_code, risk_group, campaign_category

--- a/models/olids/marts/programme/flu/flu_weekly_comparison.yml
+++ b/models/olids/marts/programme/flu/flu_weekly_comparison.yml
@@ -1,0 +1,260 @@
+version: 2
+
+models:
+  - name: flu_weekly_comparison
+    description: 'Year-over-year flu campaign comparison view showing current vs previous campaign performance.
+
+      This view provides week-aligned comparison between current and previous flu campaigns, automatically handling different campaign statuses (active vs completed) and enabling "ahead or behind" analysis.
+
+      Key Features:
+
+      • Week-by-week comparison (Week 1 current vs Week 1 previous)
+
+      • Handles campaign end dates correctly using effective_comparison_date logic
+
+      • Shows absolute and percentage differences in vaccination counts
+
+      • Includes performance indicators and trajectory analysis
+
+      • Supports both in-season and post-season comparisons
+
+      Comparison Logic:
+
+      • Active Campaign: Compares current week position to same week last year
+
+      • Completed Campaign: Compares final totals to final totals
+
+      • Mixed Status: Handles edge cases where campaigns have different completion status
+
+      Use Cases:
+
+      • "Are we ahead of or behind where we were at this point last year?"
+
+      • Weekly performance monitoring during active campaigns
+
+      • Final campaign performance evaluation
+
+      • Practice-level performance benchmarking against previous year
+
+      • Trajectory analysis for mid-campaign course corrections'
+
+    columns:
+      - name: week_number
+        description: 'Week number within campaign (1-26)'
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 26
+
+      - name: week_start_date
+        description: 'Start date of the week (Monday) for current campaign'
+        tests:
+          - not_null
+
+      - name: practice_code
+        description: 'GP practice code'
+        tests:
+          - not_null
+
+      - name: practice_name
+        description: 'GP practice name'
+        tests:
+          - not_null
+
+      - name: pcn_name
+        description: 'Primary Care Network name'
+
+      - name: practice_neighbourhood
+        description: 'Practice neighbourhood'
+
+      - name: practice_borough
+        description: 'Practice borough'
+
+      - name: risk_group
+        description: 'Risk group breakdown (e.g., Over 65, Diabetes, Total)'
+        tests:
+          - not_null
+
+      - name: campaign_category
+        description: 'Campaign category breakdown (e.g., Age Based, Clinical Condition, All Categories)'
+        tests:
+          - not_null
+
+      # Current Campaign Metrics
+      - name: current_eligible
+        description: 'Number of eligible persons in current campaign'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: current_cumulative_vaccinations
+        description: 'Cumulative vaccinations in current campaign up to this week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: current_uptake_rate
+        description: 'Current campaign uptake rate percentage'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 100
+
+      - name: current_weekly_vaccinations
+        description: 'Vaccinations administered this week in current campaign'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      # Previous Season Metrics (same week position, previous campaign)
+      - name: previous_season_eligible
+        description: 'Number of eligible persons in previous season at same week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: previous_season_cumulative_vaccinations
+        description: 'Cumulative vaccinations in previous season at same week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: previous_season_uptake_rate
+        description: 'Previous season uptake rate at same week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 100
+
+      - name: previous_season_weekly_vaccinations
+        description: 'Vaccinations in same week of previous season'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      # Year-over-year Comparison Metrics
+      - name: vaccinations_vs_previous_season
+        description: 'Difference in cumulative vaccinations (current - previous season). Positive = ahead, negative = behind'
+
+      - name: uptake_rate_difference_vs_previous_season
+        description: 'Difference in uptake rate percentage points (current - previous season)'
+
+      - name: percentage_change_vs_previous_season
+        description: 'Percentage change in vaccinations vs previous season'
+
+      - name: position_vs_previous_season
+        description: 'Year-over-year position indicator (ahead/behind/equal)'
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['AHEAD', 'BEHIND', 'EQUAL']
+
+      - name: uptake_rate_vs_previous_season
+        description: 'Year-over-year uptake rate comparison indicator'
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['HIGHER', 'LOWER', 'EQUAL']
+
+      # Campaign Context
+      - name: campaign_status
+        description: 'Status of current campaign'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['ACTIVE', 'COMPLETED', 'FUTURE']
+
+      - name: current_week_position
+        description: 'Current week position in active campaign'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 26
+
+      - name: comparison_type
+        description: 'Type of comparison being made'
+        tests:
+          - not_null
+
+      - name: current_trajectory
+        description: 'Assessment of current trajectory (for active campaigns only)'
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Strong', 'Good', 'On Track', 'Concerning', null]
+
+      # Performance Rankings
+      - name: practice_rank_current_week
+        description: 'Rank of practice by current week cumulative vaccinations'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+
+      - name: practice_rank_vs_previous_season
+        description: 'Rank of practice by improvement vs previous season'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+
+      # Aggregated Context
+      - name: pcn_total_current
+        description: 'Total current season vaccinations for this PCN at this week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: pcn_total_previous_season
+        description: 'Total previous season vaccinations for this PCN at same week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: borough_total_current
+        description: 'Total current season vaccinations for this borough at this week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+      - name: borough_total_previous_season
+        description: 'Total previous season vaccinations for this borough at same week'
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - week_number
+              - practice_code
+              - risk_group
+              - campaign_category
+          name: flu_weekly_comparison_unique_week_practice_risk
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "current_cumulative_vaccinations <= current_eligible"
+          name: flu_weekly_comparison_current_within_eligible
+
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "previous_season_cumulative_vaccinations <= previous_season_eligible"
+          name: flu_weekly_comparison_previous_season_within_eligible


### PR DESCRIPTION
## Summary
- Simplified cervical screening models to focus on core programme tracking
- Removed overcomplicated cytology parsing and risk categorisation
- Retained essential programme monitoring functionality

## Changes Made

### Simplified `int_cervical_screening_all.sql`
- Removed complex CASE statements parsing display text for cytology results
- Removed cytology_result_category, cervical_screening_risk_category, abnormality_grade
- Removed sample_adequacy and clinical_action_required fields
- Kept only core cluster-based flags (is_completed_screening, is_unsuitable_screening, etc.)

### Updated `int_cervical_screening_latest.sql`
- Removed references to dropped cytology fields
- Clean pass-through of essential fields only

### Refactored `fct_cervical_screening_status.sql`
- Simplified programme_status to: Up to Date, Overdue, Never Screened, Unsuitable, Not Eligible
- Removed risk stratification flags (requires_urgent_follow_up, requires_colposcopy_referral)
- Retained useful programme monitoring fields:
  - next_screening_due_date
  - days_overdue
  - never_screened flag
  - Latest observation type flags for transparency

### Documentation
- Updated all YAML files with simplified column documentation
- Removed references to cytology interpretation fields

## Test plan
- [ ] Run `dbt build --select +fct_cervical_screening_status` to verify models build successfully
- [ ] Verify row counts remain consistent
- [ ] Check programme_status distribution makes sense
- [ ] Confirm core programme monitoring functionality preserved