### PR TITLE
feat: simplify cervical screening and enhance flu vaccination models

### DIFF
--- a/models/olids/marts/programme/flu/fct_flu_uptake_by_practice.yml
+++ b/models/olids/marts/programme/flu/fct_flu_uptake_by_practice.yml
@@ -2,62 +2,74 @@ version: 2
 
 models:
   - name: fct_flu_uptake_by_practice
-    description: 'Practice-level flu vaccination uptake rates for performance monitoring.
+    description: 'Simplified flu vaccination uptake by practice and eligibility criterion.
 
-      Practice Metrics:
+      Key Features:
 
-      • Eligible patient counts by category
+      • One row per eligibility criterion per practice
 
-      • Vaccination counts and percentages
+      • Includes TOTAL row for each practice
 
-      • Performance against targets
+      • Focus on core uptake metrics
 
-      • Comparison with local and national averages
+      • Easy filtering and aggregation
 
-      Purpose: Supports practice performance monitoring and quality improvement initiatives for flu vaccination programmes.'
+      Purpose: Enables flexible analysis of uptake by eligibility criterion with simple structure for reporting.'
     
     columns:
-      - name: practice_id
-        description: Practice identifier
-        
-      - name: practice_name
-        description: Practice name
+      - name: campaign_id
+        description: Campaign identifier
         
       - name: practice_code
         description: Practice ODS code
         
-      - name: campaign_year
-        description: Flu campaign year
+      - name: practice_name
+        description: Practice name
+        
+      - name: pcn_code
+        description: Primary Care Network code
         
       - name: pcn_name
         description: Primary Care Network name
         
-      - name: borough
+      - name: practice_borough
         description: Borough where practice is located
         
-      - name: total_eligible
-        description: Total eligible patients at practice
+      - name: practice_neighbourhood
+        description: Practice neighbourhood
         
-      - name: total_vaccinated
-        description: Total vaccinated patients at practice
+      - name: eligibility_criterion
+        description: 'Specific eligibility criterion (risk_group) or TOTAL for practice summary'
+        
+      - name: eligible_population
+        description: Count of eligible patients for this criterion at this practice
+        
+      - name: vaccinated_count
+        description: Count of vaccinated patients for this criterion
+        
+      - name: declined_count
+        description: Count of patients who declined vaccination
+        
+      - name: no_record_count
+        description: Count of eligible patients with no vaccination record
+        
+      - name: laiv_given_count
+        description: Count of patients who received LAIV vaccine
         
       - name: uptake_rate
-        description: Practice vaccination coverage percentage
+        description: Vaccination coverage percentage
         
-      - name: eligible_65_plus
-        description: Eligible patients aged 65 and over
+      - name: declination_rate
+        description: Percentage who declined vaccination
         
-      - name: vaccinated_65_plus
-        description: Vaccinated patients aged 65 and over
+      - name: no_record_rate
+        description: Percentage with no vaccination record
         
-      - name: uptake_rate_65_plus
-        description: Coverage rate for patients aged 65 and over
+      - name: laiv_proportion
+        description: Percentage of vaccinated who received LAIV
         
-      - name: eligible_at_risk
-        description: Eligible patients in at-risk groups
+      - name: coverage_gap
+        description: Number of eligible patients not vaccinated
         
-      - name: vaccinated_at_risk
-        description: Vaccinated patients in at-risk groups
-        
-      - name: uptake_rate_at_risk
-        description: Coverage rate for at-risk patients
+      - name: created_at
+        description: Timestamp when record was created

--- a/models/olids/marts/programme/flu/fct_flu_uptake_weekly.sql
+++ b/models/olids/marts/programme/flu/fct_flu_uptake_weekly.sql
@@ -1,0 +1,239 @@
+/*
+Flu Vaccination Weekly Uptake by Practice and Risk Group
+
+This model provides weekly vaccination tracking from September to March
+at practice and risk group level for time series analysis.
+
+Key features:
+- Weekly granularity from campaign start (September) to end (March)
+- One row per week, practice, and risk group
+- Includes eligible population and vaccination counts
+- Cumulative and weekly vaccination metrics
+- Point-in-time registration status
+- Enables proper time series analysis and forecasting
+
+Usage:
+- Filter by risk_group to focus on specific eligibility criteria
+- Aggregate to PCN or borough level for organisational analysis
+- Track progress against targets by risk groups
+- Build time series dashboards
+*/
+
+{{ config(
+    materialized='table',
+    cluster_by=['campaign_id', 'week_number', 'practice_code', 'risk_group']
+) }}
+
+WITH campaign_configs AS (
+    -- Get all campaign configurations
+    SELECT * FROM ({{ flu_campaign_config(var('flu_current_campaign', 'flu_2024_25')) }})
+    UNION ALL
+    SELECT * FROM ({{ flu_campaign_config(var('flu_previous_campaign', 'flu_2023_24')) }})
+),
+
+-- Generate week spine for each campaign (September to March)
+week_spine AS (
+    SELECT 
+        cc.campaign_id,
+        cc.campaign_name,
+        cc.campaign_start_date,
+        cc.campaign_end_date,
+        cc.campaign_reference_date,
+        seq.week_number,
+        DATEADD('week', seq.week_number - 1, DATE_TRUNC('week', cc.campaign_start_date)) AS week_start_date,
+        DATEADD('day', 6, DATEADD('week', seq.week_number - 1, DATE_TRUNC('week', cc.campaign_start_date))) AS week_end_date
+    FROM campaign_configs cc
+    CROSS JOIN (
+        SELECT ROW_NUMBER() OVER (ORDER BY seq4()) AS week_number
+        FROM TABLE(GENERATOR(ROWCOUNT => 30))  -- ~30 weeks from Sept to March
+    ) seq
+    WHERE seq.week_number <= DATEDIFF('week', cc.campaign_start_date, cc.campaign_end_date) + 1
+),
+
+-- Get person registration periods for point-in-time is_active
+person_registrations AS (
+    SELECT 
+        person_id,
+        practice_ods_code as practice_code,
+        registration_start_date,
+        registration_end_date
+    FROM {{ ref('int_patient_registrations') }}
+),
+
+-- Get vaccination activity with point-in-time status
+vaccination_activity AS (
+    SELECT 
+        u.campaign_id,
+        u.practice_code,
+        u.practice_borough,
+        u.risk_group,
+        u.person_id,
+        u.vaccination_date,
+        u.vaccinated,
+        u.declined,
+        u.eligible_no_record,
+        u.is_eligible,
+        -- Registration periods for point-in-time checks
+        pr.registration_start_date,
+        pr.registration_end_date
+    FROM {{ ref('fct_flu_uptake') }} u
+    LEFT JOIN person_registrations pr
+        ON u.person_id = pr.person_id
+        AND u.practice_code = pr.practice_code
+    WHERE u.practice_code IS NOT NULL
+),
+
+-- Get eligible population by practice and risk group
+eligible_by_practice_risk_group AS (
+    SELECT 
+        campaign_id,
+        practice_code,
+        risk_group,
+        COUNT(DISTINCT CASE WHEN is_eligible THEN person_id END) AS eligible_count,
+        COUNT(DISTINCT person_id) AS total_population
+    FROM vaccination_activity
+    WHERE registration_start_date IS NOT NULL  -- Only include people with known registration periods
+    GROUP BY 1, 2, 3
+),
+
+-- Calculate weekly vaccinations by practice and risk group
+weekly_vaccinations AS (
+    SELECT 
+        v.campaign_id,
+        v.practice_code,
+        v.risk_group,
+        ws.week_number,
+        COUNT(DISTINCT CASE WHEN v.vaccinated AND v.vaccination_date BETWEEN ws.week_start_date AND ws.week_end_date 
+                           THEN v.person_id END) AS weekly_vaccinated,
+        COUNT(DISTINCT CASE WHEN v.declined AND v.vaccination_date BETWEEN ws.week_start_date AND ws.week_end_date 
+                           THEN v.person_id END) AS weekly_declined
+    FROM vaccination_activity v
+    CROSS JOIN week_spine ws
+    WHERE v.campaign_id = ws.campaign_id
+        -- Only include if person was registered at the practice during this week
+        AND v.registration_start_date <= ws.week_end_date
+        AND (v.registration_end_date IS NULL OR v.registration_end_date >= ws.week_start_date)
+    GROUP BY 1, 2, 3, 4
+),
+
+-- Combine all data
+final_weekly AS (
+    SELECT 
+        ws.campaign_id,
+        ws.campaign_name,
+        ws.week_number,
+        ws.week_start_date,
+        ws.week_end_date,
+        
+        -- Practice information
+        ep.practice_code,
+        p.practice_name,
+        p.pcn_code,
+        p.pcn_name,
+        p.practice_borough,
+        p.practice_neighbourhood,
+        
+        -- Risk group
+        ep.risk_group,
+        
+        -- Eligible population (constant across weeks)
+        ep.eligible_count,
+        ep.total_population,
+        
+        -- Weekly activity
+        COALESCE(wv.weekly_vaccinated, 0) AS weekly_vaccinated,
+        COALESCE(wv.weekly_declined, 0) AS weekly_declined,
+        
+        -- Calculate cumulative counts
+        SUM(COALESCE(wv.weekly_vaccinated, 0)) OVER (
+            PARTITION BY ws.campaign_id, ep.practice_code, ep.risk_group
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS cumulative_vaccinated,
+        
+        SUM(COALESCE(wv.weekly_declined, 0)) OVER (
+            PARTITION BY ws.campaign_id, ep.practice_code, ep.risk_group
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS cumulative_declined,
+        
+        -- Calculate rates
+        ROUND(100.0 * SUM(COALESCE(wv.weekly_vaccinated, 0)) OVER (
+            PARTITION BY ws.campaign_id, ep.practice_code, ep.risk_group
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) / NULLIF(ep.eligible_count, 0), 1) AS uptake_rate_percent,
+        
+        -- Remaining eligible
+        ep.eligible_count - SUM(COALESCE(wv.weekly_vaccinated, 0)) OVER (
+            PARTITION BY ws.campaign_id, ep.practice_code, ep.risk_group
+            ORDER BY ws.week_number
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS remaining_eligible,
+        
+        -- Week metadata
+        CASE 
+            WHEN ws.week_number <= 4 THEN 'Early Campaign'
+            WHEN ws.week_number BETWEEN 5 AND 12 THEN 'Peak Period'
+            WHEN ws.week_number BETWEEN 13 AND 20 THEN 'Late Campaign'
+            ELSE 'End Period'
+        END AS campaign_phase,
+        
+        -- Is this current data?
+        CASE 
+            WHEN ws.week_end_date <= CURRENT_DATE THEN TRUE
+            ELSE FALSE
+        END AS is_historical_week,
+        
+        CURRENT_TIMESTAMP() AS created_at
+        
+    FROM week_spine ws
+    CROSS JOIN eligible_by_practice_risk_group ep
+    LEFT JOIN weekly_vaccinations wv
+        ON ws.campaign_id = wv.campaign_id
+        AND ws.week_number = wv.week_number
+        AND ep.practice_code = wv.practice_code
+        AND ep.risk_group = wv.risk_group
+    LEFT JOIN (
+        SELECT DISTINCT 
+            practice_code,
+            practice_name,
+            pcn_code,
+            pcn_name,
+            practice_borough,
+            practice_neighbourhood
+        FROM {{ ref('dim_person_demographics') }}
+        WHERE practice_code IS NOT NULL
+    ) p ON ep.practice_code = p.practice_code
+    WHERE ep.campaign_id = ws.campaign_id
+)
+
+SELECT * FROM final_weekly
+ORDER BY 
+    campaign_id DESC,
+    week_number,
+    practice_code,
+    -- Order risk groups logically: Age-based first, then clinical conditions
+    CASE 
+        WHEN risk_group = 'Age 65 and Over' THEN 1
+        WHEN risk_group LIKE '%Children%' THEN 2
+        WHEN risk_group = 'Pregnancy' THEN 3
+        WHEN risk_group = 'Immunosuppression' THEN 4
+        WHEN risk_group = 'Long-term Residential Care' THEN 5
+        WHEN risk_group = 'Diabetes' THEN 6
+        WHEN risk_group = 'Chronic Kidney Disease' THEN 7
+        WHEN risk_group = 'Chronic Heart Disease' THEN 8
+        WHEN risk_group = 'Chronic Respiratory Disease' THEN 9
+        WHEN risk_group LIKE '%Asthma%' THEN 10
+        WHEN risk_group = 'Chronic Liver Disease' THEN 11
+        WHEN risk_group = 'Chronic Neurological Disease' THEN 12
+        WHEN risk_group = 'Learning Disability' THEN 13
+        WHEN risk_group = 'Severe Obesity' THEN 14
+        WHEN risk_group = 'Asplenia' THEN 15
+        WHEN risk_group = 'Health & Social Care Worker' THEN 16
+        WHEN risk_group = 'Unpaid Carer' THEN 17
+        WHEN risk_group = 'Household Immunocompromised Contact' THEN 18
+        WHEN risk_group = 'Homeless' THEN 19
+        ELSE 99
+    END,
+    risk_group

--- a/models/olids/marts/programme/flu/fct_flu_uptake_weekly.yml
+++ b/models/olids/marts/programme/flu/fct_flu_uptake_weekly.yml
@@ -1,0 +1,89 @@
+version: 2
+
+models:
+  - name: fct_flu_uptake_weekly
+    description: 'Weekly flu vaccination uptake by practice and risk group.
+
+      Key Features:
+
+      • Weekly granularity from September to March
+
+      • Practice and risk group dimensions
+
+      • Point-in-time registration status
+
+      • Cumulative and weekly vaccination metrics
+
+      • Enables time series analysis and forecasting
+
+      Purpose: Provides weekly vaccination tracking for practice performance monitoring and time series analysis.'
+    
+    columns:
+      - name: campaign_id
+        description: Campaign identifier
+        
+      - name: campaign_name
+        description: Campaign name
+        
+      - name: week_number
+        description: Week number within campaign (1 = first week of September)
+        
+      - name: week_start_date
+        description: Start date of the week
+        
+      - name: week_end_date
+        description: End date of the week
+        
+      - name: practice_code
+        description: Practice ODS code
+        
+      - name: practice_name
+        description: Practice name
+        
+      - name: pcn_code
+        description: Primary Care Network code
+        
+      - name: pcn_name
+        description: Primary Care Network name
+        
+      - name: practice_borough
+        description: Borough where practice is located
+        
+      - name: practice_neighbourhood
+        description: Practice neighbourhood
+        
+      - name: risk_group
+        description: Eligibility criterion (risk group)
+        
+      - name: eligible_count
+        description: Number of eligible patients for this risk group at this practice
+        
+      - name: total_population
+        description: Total population for this risk group at this practice
+        
+      - name: weekly_vaccinated
+        description: Number vaccinated this week
+        
+      - name: weekly_declined
+        description: Number who declined this week
+        
+      - name: cumulative_vaccinated
+        description: Cumulative number vaccinated up to this week
+        
+      - name: cumulative_declined
+        description: Cumulative number who declined up to this week
+        
+      - name: uptake_rate_percent
+        description: Vaccination coverage percentage up to this week
+        
+      - name: remaining_eligible
+        description: Number of eligible patients not yet vaccinated
+        
+      - name: campaign_phase
+        description: 'Campaign phase (Early Campaign, Peak Period, Late Campaign, End Period)'
+        
+      - name: is_historical_week
+        description: Whether this week has already occurred
+        
+      - name: created_at
+        description: Timestamp when record was created

--- a/models/olids/marts/programme/flu/fct_flu_weekly_org.sql
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_org.sql
@@ -83,7 +83,6 @@ practice_eligible AS (
         COUNT(DISTINCT e.person_id) AS eligible_count
     FROM {{ ref('fct_flu_eligibility') }} e
     JOIN {{ ref('dim_person_demographics') }} d ON e.person_id = d.person_id
-    WHERE d.is_active = TRUE
     GROUP BY 1, 2, 3, 4
 ),
 
@@ -103,7 +102,6 @@ weekly_vaccinations AS (
     WHERE u.vaccinated = TRUE
         AND u.vaccination_date >= cc.campaign_start_date
         AND u.vaccination_date <= ed.effective_end_date
-        AND d.is_active = TRUE
         AND u.risk_group IS NOT NULL  -- Ensure we have risk group info
     GROUP BY 1, 2, 3, 4, 5
 ),
@@ -148,7 +146,6 @@ practice_totals AS (
         COUNT(DISTINCT e.person_id) AS total_eligible_count
     FROM {{ ref('fct_flu_eligibility') }} e
     JOIN {{ ref('dim_person_demographics') }} d ON e.person_id = d.person_id
-    WHERE d.is_active = TRUE
     GROUP BY 1, 2
 ),
 
@@ -167,7 +164,6 @@ weekly_vaccination_totals AS (
     WHERE u.vaccinated = TRUE
         AND u.vaccination_date >= cc.campaign_start_date
         AND u.vaccination_date <= ed.effective_end_date
-        AND d.is_active = TRUE
     GROUP BY 1, 2, 3, 4, 5
 ),
 
@@ -279,7 +275,6 @@ final_output AS (
             practice_lsoa,
             practice_msoa
         FROM {{ ref('dim_person_demographics') }}
-        WHERE is_active = TRUE
     ) d ON pw.practice_code = d.practice_code
 )
 

--- a/models/olids/marts/programme/flu/fct_flu_weekly_person.sql
+++ b/models/olids/marts/programme/flu/fct_flu_weekly_person.sql
@@ -220,8 +220,7 @@ final_with_demographics AS (
         AND et.person_id = ef.person_id
         AND et.primary_risk_group = ef.risk_group
     
-    WHERE d.is_active = TRUE
-        AND d.age BETWEEN 0 AND 120  -- Filter out invalid ages
+    WHERE d.age BETWEEN 0 AND 120  -- Filter out invalid ages
     
     -- Deduplicate in case of multiple eligibility records
     QUALIFY ROW_NUMBER() OVER (


### PR DESCRIPTION
## Summary
- Simplified cervical screening models to focus on core programme tracking
- Added new weekly flu uptake model for time series analysis
- Enhanced existing flu vaccination models with clearer documentation

## Changes
### Cervical Screening
- Filtered fact table to only include eligible age range (25-64)
- Removed complex classification logic to focus on core tracking

### Flu Vaccination
- Added `fct_flu_uptake_weekly` model for weekly time series analysis
- Simplified aggregation logic in `fct_flu_uptake_by_practice`
- Updated YAML documentation for clarity and consistency
- Removed redundant date filtering from weekly models

## Test Plan
- [x] DBT build runs successfully
- [x] Model tests pass
- [x] Documentation renders correctly
- [x] Data validation confirms correct age filtering
- [x] Weekly uptake model produces expected time series