### PR TITLE
fix: remove database fallback value in dbt_project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -31,14 +31,14 @@ tests:
 models:
   'dbt_olids':
     +materialized: table
-    +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE', 'DATA_LAB_OLIDS_UAT') }}"
+    +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}"
     +persist_docs:
       columns: true
     
     # Domain-specific configurations
     olids:
       +materialized: table
-      +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE', 'DATA_LAB_OLIDS_UAT') }}"
+      +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}"
       staging:
         +materialized: view
         +post-hook: ["{{ add_model_comment() }}"]
@@ -54,7 +54,7 @@ models:
     
     shared:
       +materialized: table
-      +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE', 'DATA_LAB_OLIDS_UAT') }}"
+      +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}"
       staging:
         +materialized: view
         +post-hook: ["{{ add_model_comment() }}"]


### PR DESCRIPTION
## Summary
- Remove hardcoded fallback value 'DATA_LAB_OLIDS_UAT' from SNOWFLAKE_TARGET_DATABASE environment variable configuration
- Ensures explicit environment configuration is required, preventing accidental use of default values

## Changes
- Updated `dbt_project.yml` to use `env_var('SNOWFLAKE_TARGET_DATABASE')` without fallback value in three locations:
  - Main model configuration
  - OLIDS model configuration  
  - Shared model configuration

## Impact
This change ensures that the database target must be explicitly set via environment variable, preventing unintended deployments to the UAT database when the environment variable is not configured.