### PR TITLE
perf: optimise concept mapping joins in performance models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: [feat, fix, docs, refactor, test, chore]
+        args: [feat, fix, docs, refactor, test, chore, perf]
 
   # SQL formatting with SQLFluff (never blocks commits)
   - repo: local

--- a/models/olids/intermediate/performance/int_medication_orders_mapped.sql
+++ b/models/olids/intermediate/performance/int_medication_orders_mapped.sql
@@ -30,7 +30,7 @@ SELECT
     mo.id as medication_order_id,
     mo.medication_statement_id,
     mo.patient_id,
-    mo.person_id,
+    -- person_id excluded as it's rarely populated in source, use patient_person join instead
     mo.clinical_effective_date::DATE as order_date,
     
     -- Order details
@@ -55,9 +55,9 @@ SELECT
 FROM {{ ref('stg_olids_medication_order') }} mo
 JOIN {{ ref('stg_olids_medication_statement') }} ms
     ON mo.medication_statement_id = ms.id
-LEFT JOIN {{ ref('stg_olids_terminology_concept_map') }} cm
+INNER JOIN {{ ref('stg_olids_terminology_concept_map') }} cm
     ON ms.medication_statement_core_concept_id = cm.source_code_id
-LEFT JOIN {{ ref('stg_olids_terminology_concept') }} c
+INNER JOIN {{ ref('stg_olids_terminology_concept') }} c
     ON cm.target_code_id = c.id
 WHERE mo.clinical_effective_date IS NOT NULL
 

--- a/models/olids/intermediate/person_attributes/int_patient_person_unique.sql
+++ b/models/olids/intermediate/person_attributes/int_patient_person_unique.sql
@@ -12,7 +12,7 @@ This intermediate model prevents duplicate persons in downstream models
 that join observations/medications to person data.
 EXCLUDES orphaned person records that don't link to valid patient records.
 */
-SELECT
+SELECT DISTINCT
     pp.patient_id,
     pp.person_id,
     pat.sk_patient_id
@@ -26,8 +26,4 @@ WHERE pp.patient_id IS NOT NULL
     AND pp.person_id IS NOT NULL
     -- Only include patients with basic demographics
     AND pat.birth_year IS NOT NULL
-QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY pp.person_id
-    ORDER BY pp.patient_id
-) = 1
 ORDER BY person_id, patient_id


### PR DESCRIPTION
## Summary
- Change LEFT JOINs to INNER JOINs for concept mapping in performance models
- Remove unused person_id fields (rarely populated in source data)  
- Update int_patient_person_unique to use DISTINCT for deduplication
- Add perf to conventional commit types configuration

## Test plan
- [x] Run dbt build on performance models to ensure no errors
- [x] Validate row counts haven't changed unexpectedly
- [x] Check query performance improvements in dev environment