### PR TITLE
feat: update flu campaign to 2025-26 and fix vaccination date filtering

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,8 +17,8 @@ vars:
   dbt_audit_schema: "test_audit"  # Cleaner name instead of dbt_dbt_test_audit
   
   # Flu campaign configuration - Change these values to run for different campaign years
-  flu_current_campaign: "flu_2024_25"     # Current flu campaign (flu_2023_24, flu_2024_25, flu_2025_26)
-  flu_previous_campaign: "flu_2023_24"    # Previous flu campaign (for year-over-year comparison)
+  flu_current_campaign: "flu_2025_26"     # Current flu campaign (flu_2023_24, flu_2024_25, flu_2025_26)
+  flu_previous_campaign: "flu_2024_25"    # Previous flu campaign (for year-over-year comparison)
   flu_audit_end_date: "CURRENT_DATE"      # Default audit end date
 
 # Configure test failure storage (only for failures)

--- a/models/olids/intermediate/programme/flu/int_flu_children_preschool.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_children_preschool.sql
@@ -4,7 +4,7 @@ Children Preschool Age Eligibility Rule
 Business Rule: Person is eligible if they are:
 1. Born between the campaign-specific date range for preschool children
    (age range varies by campaign year - typically 2-3 years old)
-   (e.g., Sept 2020 to Aug 2022 for 2024-25 campaign)
+   (dates determined by campaign configuration child_preschool_birth_start/end)
 
 Pure birth date range rule - no clinical codes, just demographics.
 Age-agnostic naming allows for year-to-year age range changes.

--- a/models/olids/intermediate/programme/flu/int_flu_children_school_age.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_children_school_age.sql
@@ -4,7 +4,7 @@ Children School Age Eligibility Rule
 Business Rule: Person is eligible if they are:
 1. Born between the campaign-specific date range for school age children
    (age range varies by campaign year - typically 4-16 years old)
-   (e.g., Sept 2008 to Aug 2020 for 2024-25 campaign)
+   (dates determined by campaign configuration child_school_age_birth_start/end)
 
 Pure birth date range rule - no clinical codes, just demographics.
 Age-agnostic naming allows for year-to-year age range changes.

--- a/models/olids/intermediate/programme/flu/int_flu_laiv_vaccination.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_laiv_vaccination.sql
@@ -30,7 +30,7 @@ people_with_laiv_vaccination_admin AS (
     CROSS JOIN all_campaigns cc
     WHERE obs.clinical_effective_date IS NOT NULL
         AND obs.clinical_effective_date > cc.laiv_vaccination_after_date
-        AND obs.clinical_effective_date <= cc.audit_end_date
+        AND obs.clinical_effective_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, obs.person_id
 ),
 
@@ -45,7 +45,7 @@ people_with_laiv_vaccination_medication AS (
     CROSS JOIN all_campaigns cc
     WHERE med.order_date IS NOT NULL
         AND med.order_date > cc.laiv_vaccination_after_date
-        AND med.order_date <= cc.audit_end_date
+        AND med.order_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, med.person_id
 ),
 

--- a/models/olids/intermediate/programme/flu/int_flu_pregnancy.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_pregnancy.sql
@@ -6,9 +6,9 @@ Business Rule: Person is eligible if they have:
 2. Scenario B: Became pregnant between campaign start and reference date (remains eligible even if delivered)
 3. AND aged 12 years or older (minimum age for pregnancy flu vaccination)
 
-For 2024-25 campaign:
-- Scenario A: Pregnant on 2024-01-01 with no delivery after that date
-- Scenario B: Pregnancy code between 2024-09-01 and 2025-03-31
+Campaign-specific logic:
+- Scenario A: Pregnant 9 months before campaign start with no subsequent delivery
+- Scenario B: Pregnancy code between campaign_start_date and campaign_reference_date
 
 Simplified rule - focuses on flu season timing rather than complex pregnancy state logic.
 */

--- a/models/olids/intermediate/programme/flu/int_flu_vaccination_declined.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_vaccination_declined.sql
@@ -34,7 +34,7 @@ people_with_declined_codes AS (
     WHERE obs.clinical_effective_date IS NOT NULL
         -- Restrict to current campaign period (after previous campaign's vaccination tracking date)
         AND obs.clinical_effective_date > cc.flu_vaccination_after_date
-        AND obs.clinical_effective_date <= cc.audit_end_date
+        AND obs.clinical_effective_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, obs.person_id
 ),
 
@@ -50,7 +50,7 @@ people_with_no_consent_codes AS (
     WHERE obs.clinical_effective_date IS NOT NULL
         -- Restrict to current campaign period (after previous campaign's vaccination tracking date)
         AND obs.clinical_effective_date > cc.flu_vaccination_after_date
-        AND obs.clinical_effective_date <= cc.audit_end_date
+        AND obs.clinical_effective_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, obs.person_id
 ),
 

--- a/models/olids/intermediate/programme/flu/int_flu_vaccination_given.sql
+++ b/models/olids/intermediate/programme/flu/int_flu_vaccination_given.sql
@@ -33,7 +33,7 @@ people_with_flu_vaccination_admin AS (
     CROSS JOIN all_campaigns cc
     WHERE obs.clinical_effective_date IS NOT NULL
         AND obs.clinical_effective_date > cc.flu_vaccination_after_date
-        AND obs.clinical_effective_date <= cc.audit_end_date
+        AND obs.clinical_effective_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, obs.person_id
 ),
 
@@ -48,7 +48,7 @@ people_with_flu_vaccination_medication AS (
     CROSS JOIN all_campaigns cc
     WHERE med.order_date IS NOT NULL
         AND med.order_date > cc.flu_vaccination_after_date
-        AND med.order_date <= cc.audit_end_date
+        AND med.order_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, med.person_id
 ),
 
@@ -63,7 +63,7 @@ people_with_laiv_vaccination_admin AS (
     CROSS JOIN all_campaigns cc
     WHERE obs.clinical_effective_date IS NOT NULL
         AND obs.clinical_effective_date > cc.laiv_vaccination_after_date
-        AND obs.clinical_effective_date <= cc.audit_end_date
+        AND obs.clinical_effective_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, obs.person_id
 ),
 
@@ -78,7 +78,7 @@ people_with_laiv_vaccination_medication AS (
     CROSS JOIN all_campaigns cc
     WHERE med.order_date IS NOT NULL
         AND med.order_date > cc.laiv_vaccination_after_date
-        AND med.order_date <= cc.audit_end_date
+        AND med.order_date <= cc.campaign_end_date
     GROUP BY cc.campaign_id, med.person_id
 ),
 


### PR DESCRIPTION
## Summary
- Update flu campaign configuration from 2024-25 to 2025-26 
- Fix vaccination date filtering bug that was including post-campaign vaccinations
- Remove legacy documentation folder

## Changes Made
- **dbt_project.yml**: Updated flu_current_campaign to `flu_2025_26` and flu_previous_campaign to `flu_2024_25`
- **Model documentation**: Replaced hardcoded date examples with dynamic parameter references  
- **Vaccination models**: Fixed date filtering to use `campaign_end_date` instead of `audit_end_date`
- **Legacy cleanup**: Removed legacy folder that is no longer needed

## Bug Fix Details
The key issue was that vaccination tracking models were using `audit_end_date` (CURRENT_DATE) instead of `campaign_end_date` as the upper bound for vaccination dates. This meant historical campaigns like 2023-24 were incorrectly including vaccinations that occurred after the campaign end date (March 31, 2024).

**Fixed models:**
- `int_flu_vaccination_given.sql`
- `int_flu_vaccination_declined.sql` 
- `int_flu_laiv_vaccination.sql`

## Test Plan
- [x] Run flu models for 2025-26 campaign
- [x] Verify 2023-24 campaign vaccinations are properly bounded by March 31, 2024
- [x] Check campaign date configuration is correctly applied across all models