### PR TITLE
fix: correct valproate ARAF date logic and action prioritisation

### DIFF
--- a/models/olids/marts/programme/valproate/dim_valproate_action_status.yml
+++ b/models/olids/marts/programme/valproate/dim_valproate_action_status.yml
@@ -1,6 +1,40 @@
 version: 2
 models:
   - name: dim_valproate_action_status
-    description: 'Valproate safety monitoring with clinical decision logic and priority actions (1-9).
-
-      One row per person calculating recommended actions based on pregnancy status, PPP enrollment, ARAF completion, age and risk factors.'
+    description: |
+      Valproate safety monitoring clinical decision logic implementing MHRA guidelines for teratogen risk management.
+      
+      **CLINICAL DECISION FRAMEWORK:**
+      
+      This model categorises patients based on safety documentation completeness and vulnerability factors:
+      
+      - **Safety Documentation Requirements:**
+        - PPP (Pregnancy Prevention Programme): Must be enrolled or explicitly declined/discontinued  
+        - ARAF (Annual Risk Acknowledgement Form): Must be current within lookback period
+      
+      - **Vulnerability Factors:**
+        - Pregnancy status (highest risk)
+        - Learning disability (requires additional support)
+        - Age-based reproductive risk: 0-6 (low), 7-12 (medium), 13-60 (high)
+        - Permanent absence of pregnancy risk (lowest risk)
+      
+      **ACTION CATEGORIES:**
+      
+      1. **"Review or refer"** - Missing safety documentation or high-risk situations requiring immediate clinical review
+      2. **"Keep under review"** - PPP declined/discontinued but documented; routine monitoring sufficient  
+      3. **"Consider expiry of ARAF"** - All safety measures present; check if ARAF needs renewal
+      4. **"No action required"** - Low risk patients requiring minimal intervention
+      
+      **PRIORITY ORDER (1 = Most Urgent, 9 = Least Urgent):**
+      
+      1. **PREGNANCY** - Immediate teratogenic risk, urgent review required
+      2. **MISSING DOCS + LEARNING DISABILITY** - Vulnerable population without safety measures
+      3. **MISSING DOCS + HIGH RISK AGE (13-60)** - Prime reproductive age without safety measures
+      4. **MISSING DOCS + MEDIUM RISK AGE (7-12)** - Approaching reproductive age without safety measures  
+      5. **PPP DECLINED** - Documented decision to decline PPP, routine monitoring
+      6. **COMPLETE DOCS + LEARNING DISABILITY** - Monitor ARAF expiry in vulnerable population
+      7. **COMPLETE DOCS + MEDIUM RISK AGE (7-12)** - Monitor ARAF expiry
+      8. **COMPLETE DOCS + HIGH RISK AGE (13-60)** - Monitor ARAF expiry  
+      9. **LOW RISK** - Age 0-6 or permanent absence of pregnancy risk, minimal monitoring
+      
+      One row per person in valproate cohort (non-males aged 0-55 with recent valproate orders).

--- a/models/olids/marts/programme/valproate/dim_valproate_araf.sql
+++ b/models/olids/marts/programme/valproate/dim_valproate_araf.sql
@@ -10,6 +10,12 @@ WITH person_level_araf_aggregation AS (
         max(
             CASE WHEN is_specific_araf_form_code THEN araf_event_date END
         ) AS latest_specific_araf_form_date,
+        max(
+            CASE WHEN araf_concept_code = '1366401000000107' THEN araf_event_date END
+        ) AS latest_old_araf_date,
+        max(
+            CASE WHEN araf_concept_code = '2078951000000106' THEN araf_event_date END
+        ) AS latest_new_araf_date,
         boolor_agg(is_specific_araf_form_code)
             AS has_specific_araf_form_meeting_lookback,
         array_agg(DISTINCT araf_observation_id) AS all_araf_observation_ids,
@@ -27,6 +33,8 @@ SELECT
     pla.earliest_araf_event_date,
     pla.latest_araf_event_date,
     pla.latest_specific_araf_form_date,
+    pla.latest_old_araf_date,
+    pla.latest_new_araf_date,
     pla.all_araf_observation_ids,
     pla.all_araf_concept_codes,
     pla.all_araf_concept_displays,
@@ -38,16 +46,27 @@ SELECT
     array_contains('1366401000000107'::VARIANT, pla.all_araf_concept_codes) AS has_old_annual_risk_acknowledgement_form,
     array_contains('2078951000000106'::VARIANT, pla.all_araf_concept_codes) AS has_new_annual_risk_acknowledgement_form,
     
-    -- ARAF form type info with dates
+    -- Latest ARAF overall date (matching legacy logic: prioritise new over old if both exist)
     CASE 
-        WHEN array_contains('1366401000000107'::VARIANT, pla.all_araf_concept_codes) 
-        THEN 'Yes (' || TO_VARCHAR(pla.latest_specific_araf_form_date, 'DD/MM/YYYY') || ')' 
+        WHEN pla.latest_new_araf_date IS NOT NULL THEN 
+            CASE 
+                WHEN pla.latest_old_araf_date IS NOT NULL AND pla.latest_old_araf_date > pla.latest_new_araf_date 
+                THEN pla.latest_old_araf_date 
+                ELSE pla.latest_new_araf_date 
+            END
+        ELSE pla.latest_old_araf_date 
+    END AS latest_araf_overall_date,
+    
+    -- ARAF form type info with actual dates for each form type
+    CASE 
+        WHEN pla.latest_old_araf_date IS NOT NULL 
+        THEN 'Yes (' || TO_VARCHAR(pla.latest_old_araf_date, 'DD/MM/YYYY') || ')' 
         ELSE 'No' 
     END AS old_annual_risk_acknowledgement_form_info,
     
     CASE 
-        WHEN array_contains('2078951000000106'::VARIANT, pla.all_araf_concept_codes) 
-        THEN 'Yes (' || TO_VARCHAR(pla.latest_specific_araf_form_date, 'DD/MM/YYYY') || ')' 
+        WHEN pla.latest_new_araf_date IS NOT NULL 
+        THEN 'Yes (' || TO_VARCHAR(pla.latest_new_araf_date, 'DD/MM/YYYY') || ')' 
         ELSE 'No' 
     END AS new_annual_risk_acknowledgement_form_info
     

--- a/models/olids/marts/programme/valproate/dim_valproate_araf.yml
+++ b/models/olids/marts/programme/valproate/dim_valproate_araf.yml
@@ -1,6 +1,33 @@
 version: 2
 models:
   - name: dim_valproate_araf
-    description: 'Annual Risk Acknowledgement Form (ARAF) events aggregation for valproate monitoring.
-
-      One row per person with ARAF events including earliest and latest dates, compliance flags and form type information.'
+    description: |
+      Annual Risk Acknowledgement Form (ARAF) events aggregation for valproate safety monitoring.
+      
+      **PURPOSE:**
+      Tracks ARAF completion status for patients on valproate, supporting MHRA teratogen risk management requirements.
+      
+      **KEY FEATURES:**
+      
+      - **ARAF Form Types Supported:**
+        - Old ARAF (SNOMED: 1366401000000107) - Legacy annual risk acknowledgement form
+        - New ARAF (SNOMED: 2078951000000106) - Current annual risk acknowledgement form
+      
+      - **Date Tracking:**
+        - Separate tracking of old vs new ARAF form dates
+        - Overall latest ARAF date calculation (prioritises most recent between form types)
+        - Lookback period compliance based on valproate programme codes
+      
+      - **Form Status Information:**
+        - Boolean flags for each ARAF form type presence
+        - Formatted info strings showing actual completion dates for each form type
+        - Compliance status based on lookback requirements
+      
+      **BUSINESS RULES:**
+      
+      - Only includes persons with at least one ARAF event meeting lookback criteria
+      - `latest_araf_overall_date` uses legacy logic: picks most recent between old/new forms
+      - Info strings show "Yes (DD/MM/YYYY)" for completed forms, "No" for missing forms
+      - All observation IDs, concept codes, and displays preserved for audit trail
+      
+      One row per person with any ARAF events meeting programme criteria.


### PR DESCRIPTION
## Summary

Fixed logical inconsistencies in valproate ARAF (Annual Risk Acknowledgement Form) date handling and action prioritisation that were causing incorrect clinical decision outputs.

## Issues Found

### 1. ARAF Date Logic Problem
**Issue:** Both `old_annual_risk_acknowledgement_form_info` and `new_annual_risk_acknowledgement_form_info` were showing the same generic `latest_specific_araf_form_date` instead of the actual date of each specific form type.

**Impact:** Patients with both old and new ARAF forms would show identical dates for both form types, making it impossible to distinguish which form was completed when.

**Fix:** 
- Added separate date calculations for old ARAF (SNOMED: `1366401000000107`) and new ARAF (SNOMED: `2078951000000106`)
- Info strings now show actual completion dates for each specific form type
- Added `latest_araf_overall_date` field matching legacy platform logic

### 2. Action Order Prioritisation Problem  
**Issue:** Overlapping OR logic in CASE statements caused all patients with missing PPP to receive Priority 2, regardless of age or vulnerability factors.

```sql
-- PROBLEMATIC LOGIC:
WHEN has_ppp_event = FALSE OR (missing_araf AND learning_disability) THEN priority_2
WHEN has_ppp_event = FALSE OR (missing_araf AND age_13_60) THEN priority_3  -- Never reached!
WHEN has_ppp_event = FALSE OR (missing_araf AND age_7_12) THEN priority_4   -- Never reached!
```

**Impact:** 
- 25-year-old with no PPP → Got Priority 2 (should be Priority 3)
- 10-year-old with no PPP → Got Priority 2 (should be Priority 4)  
- Age-based and learning disability distinctions were ignored

**Fix:** Restructured logic to properly stratify by vulnerability:
```sql
-- FIXED LOGIC:
WHEN (missing_ppp OR missing_araf) AND learning_disability THEN priority_2
WHEN (missing_ppp OR missing_araf) AND age_13_60 THEN priority_3
WHEN (missing_ppp OR missing_araf) AND age_7_12 THEN priority_4
```

## Changes Made

### Files Modified:
- `models/olids/marts/programme/valproate/dim_valproate_araf.sql`
- `models/olids/marts/programme/valproate/dim_valproate_araf.yml`  
- `models/olids/marts/programme/valproate/dim_valproate_action_status.sql`
- `models/olids/marts/programme/valproate/dim_valproate_action_status.yml`

### New Columns Added:
- `latest_old_araf_date` - Latest date for old ARAF form
- `latest_new_araf_date` - Latest date for new ARAF form  
- `latest_araf_overall_date` - Most recent date between form types (legacy logic)

### Documentation Enhancements:
- Comprehensive inline SQL comments explaining clinical decision logic
- Updated YAML descriptions describing priority framework
- Detailed business rules and SNOMED code documentation

## Breaking Changes ⚠️

**Interface Changes:**
- New columns in `dim_valproate_araf`
- Changed content in ARAF info strings (now show form-specific dates)
- Changed `action_order` values for patients with missing documentation (proper stratification)

**Downstream Impact:**
- Reports/dashboards using ARAF info strings will now show correct dates
- New columns will need to be handled in dependent models

## Test Plan

- [x] Run `dbt build --select +dim_valproate_araf+ +dim_valproate_action_status+`
- [ ] Verify action_order distribution matches clinical expectations
- [ ] Check if ARAF and new ARAF counts are now correct
- [ ] Compare outputs with HealtheIntent platform for validation
- [ ] Update any downstream dependencies for new interface

## Clinical Validation

The fixed logic now properly implements the intended clinical decision tree:
1. **Priority 1:** Pregnancy (urgent review)
2. **Priority 2-4:** Missing safety documentation (stratified by vulnerability)
3. **Priority 5:** PPP declined (routine monitoring) 
4. **Priority 6-8:** Complete documentation (ARAF expiry monitoring)
5. **Priority 9:** Low risk (minimal intervention)

Fixes #191 