### PR TITLE
fix: resolve postcode_hash missing from demographics tables

### DIFF
--- a/models/olids/intermediate/person_attributes/int_person_postcode_hash.sql
+++ b/models/olids/intermediate/person_attributes/int_person_postcode_hash.sql
@@ -1,0 +1,38 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+Person Postcode Hash
+Gets the current postcode_hash for each person via patient address.
+*/
+
+WITH current_addresses AS (
+    -- Get the latest address for each person using SCD2 logic
+    SELECT 
+        pp.person_id,
+        pa.postcode_hash,
+        pa.lds_start_date_time,
+        pa.lds_end_date_time
+    FROM {{ ref('int_patient_person_unique') }} pp
+    INNER JOIN {{ ref('stg_olids_patient_address') }} pa
+        ON pp.patient_id = pa.patient_id
+    WHERE pa.lds_start_date_time IS NOT NULL
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY pp.person_id 
+        ORDER BY 
+            CASE WHEN pa.lds_end_date_time IS NULL THEN 0 ELSE 1 END,  -- Active addresses first
+            pa.lds_start_date_time DESC,
+            pa.lds_datetime_data_acquired DESC
+    ) = 1
+)
+
+SELECT
+    person_id,
+    postcode_hash,
+    lds_start_date_time as address_start_date,
+    lds_end_date_time as address_end_date,
+    CASE WHEN lds_end_date_time IS NULL THEN TRUE ELSE FALSE END as is_current_address
+FROM current_addresses


### PR DESCRIPTION
## Summary
- Resolves issue where `postcode_hash` showed 100% NULL values in `dim_person_demographics` and `dim_person_demographics_historical` despite being well populated in source tables
- Root cause was using `start_date` (always NULL) instead of `lds_start_date_time` for SCD2 temporal filtering
- Also addresses BINARY field handling issues in join logic

## Changes
- **New**: `int_person_postcode_hash` intermediate model to isolate postcode_hash join logic
- **Fix**: Use `lds_start_date_time`/`lds_end_date_time` instead of `start_date`/`end_date` for SCD2 tracking
- **Update**: `dim_person_demographics` to use new intermediate model
- **Update**: `dim_person_demographics_historical` to use new intermediate model with proper temporal logic
- **Remove**: Problematic `postcode_hash IS NOT NULL` filter that was causing join failures with BINARY fields

## Test plan
- [x] Verified `int_person_postcode_hash` returns data (previously 0 rows, now populated)
- [x] Confirmed postcode_hash values now flow through to demographics tables
- [x] Validated temporal logic works correctly for historical demographics

Fixes issue where postcode data wasn't available for geographic analysis in demographics models.