### PR TITLE
feat: add housebound status tracking and school fields to COVID/flu dashboard

### DIFF
--- a/models/olids/intermediate/person_attributes/int_housebound_status_all.sql
+++ b/models/olids/intermediate/person_attributes/int_housebound_status_all.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All housebound status observations from ECL source.
+Uses cluster IDs: HOUSEBOUND and NO_LONGER_HOUSEBOUND.
+*/
+
+SELECT
+    obs.observation_id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS code_description,
+    obs.cluster_id AS source_cluster_id
+FROM ({{ get_observations("'HOUSEBOUND', 'NO_LONGER_HOUSEBOUND'", source='ECL_CACHE') }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+ORDER BY person_id, clinical_effective_date DESC

--- a/models/olids/intermediate/person_attributes/int_housebound_status_all.yml
+++ b/models/olids/intermediate/person_attributes/int_housebound_status_all.yml
@@ -1,0 +1,10 @@
+version: 2
+models:
+  - name: int_housebound_status_all
+    description: 'Housebound status observations from ECL source.
+
+      One row per housebound status observation using HOUSEBOUND and NO_LONGER_HOUSEBOUND clusters.'
+    tests:
+      - cluster_ids_exist:
+          arguments:
+            cluster_ids: HOUSEBOUND, NO_LONGER_HOUSEBOUND

--- a/models/olids/marts/person_status/dim_person_housebound_status.sql
+++ b/models/olids/marts/person_status/dim_person_housebound_status.sql
@@ -1,0 +1,50 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'housebound', 'mobility'],
+        cluster_by=['person_id'])
+}}
+
+-- Person Housebound Status Dimension Table
+-- Holds the latest housebound status for persons who have a recorded housebound status
+-- Only includes persons who have a record in HOUSEBOUND or NO_LONGER_HOUSEBOUND clusters
+
+WITH latest_housebound_status AS (
+    SELECT
+        hbs.person_id,
+        pp.sk_patient_id,
+        hbs.clinical_effective_date,
+        hbs.concept_code,
+        hbs.code_description,
+        hbs.source_cluster_id,
+        -- Determine current housebound status
+        CASE
+            WHEN hbs.source_cluster_id = 'HOUSEBOUND' THEN TRUE
+            WHEN hbs.source_cluster_id = 'NO_LONGER_HOUSEBOUND' THEN FALSE
+            ELSE NULL
+        END AS is_housebound,
+        -- Status description
+        CASE
+            WHEN hbs.source_cluster_id = 'HOUSEBOUND' THEN 'Housebound'
+            WHEN hbs.source_cluster_id = 'NO_LONGER_HOUSEBOUND' THEN 'Not Housebound'
+            ELSE 'Unknown'
+        END AS housebound_status
+    FROM {{ ref('int_housebound_status_all') }} hbs
+    JOIN {{ ref('int_patient_person_unique') }} pp
+        ON hbs.person_id = pp.person_id
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY hbs.person_id
+        ORDER BY hbs.clinical_effective_date DESC, hbs.observation_id DESC
+    ) = 1
+)
+
+SELECT
+    person_id,
+    sk_patient_id,
+    clinical_effective_date AS latest_housebound_status_date,
+    concept_code,
+    code_description,
+    source_cluster_id,
+    is_housebound,
+    housebound_status
+FROM latest_housebound_status

--- a/models/olids/marts/person_status/dim_person_housebound_status.yml
+++ b/models/olids/marts/person_status/dim_person_housebound_status.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: dim_person_housebound_status
+    description: 'Latest housebound status for persons.
+
+      One row per person with their most recent housebound status from HOUSEBOUND or NO_LONGER_HOUSEBOUND clusters.'
+    columns:
+      - name: person_id
+        description: Person identifier
+        tests:
+          - unique
+          - not_null
+      - name: sk_patient_id
+        description: Surrogate key for patient
+      - name: latest_housebound_status_date
+        description: Date of most recent housebound status observation
+        tests:
+          - not_null
+      - name: is_housebound
+        description: Boolean flag indicating if person is currently housebound
+        tests:
+          - not_null
+      - name: housebound_status
+        description: Text description of housebound status
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Housebound', 'Not Housebound']

--- a/models/olids/marts/published_reporting_direct_care/covid_flu_dashboard_base.sql
+++ b/models/olids/marts/published_reporting_direct_care/covid_flu_dashboard_base.sql
@@ -68,6 +68,14 @@ WITH uptake_with_demographics AS (
         d.practice_borough,
         d.practice_neighbourhood,
         
+        -- School information from dim_person_age
+        pa.age_school_stage AS school_year,
+        pa.is_primary_school_age,
+        pa.is_secondary_school_age,
+        
+        -- Housebound status from dim_person_housebound_status
+        COALESCE(hs.is_housebound, FALSE) AS is_housebound,
+        
         -- Eligibility information from uptake facts
         u.is_eligible,
         u.campaign_category,
@@ -100,6 +108,10 @@ WITH uptake_with_demographics AS (
     FROM {{ ref('fct_covid_flu_uptake') }} u
     LEFT JOIN {{ ref('dim_person_demographics') }} d
         ON u.person_id = d.person_id
+    LEFT JOIN {{ ref('dim_person_age') }} pa
+        ON u.person_id = pa.person_id
+    LEFT JOIN {{ ref('dim_person_housebound_status') }} hs
+        ON u.person_id = hs.person_id
 )
 
 SELECT * FROM uptake_with_demographics


### PR DESCRIPTION
## Summary
- Added housebound status tracking capability through new intermediate and dimension models
- Enhanced COVID/flu dashboard with school year and school age flags for education-based analysis
- Integrated housebound status flag into dashboard for accessibility considerations

## Changes
### New Models
- `int_housebound_status_all`: Collects housebound observations from ECL_CACHE source
- `dim_person_housebound_status`: Provides latest housebound status per person

### Dashboard Enhancements
- Added `school_year` field showing specific school year (Reception, Year 1-13, etc.)
- Added `is_primary_school_age` and `is_secondary_school_age` boolean flags
- Added `is_housebound` flag for identifying patients requiring home visits

## Test Plan
- [x] Verify int_housebound_status_all collects HOUSEBOUND and NO_LONGER_HOUSEBOUND clusters
- [x] Confirm dim_person_housebound_status correctly identifies latest status per person
- [x] Check covid_flu_dashboard_base includes new fields with appropriate joins