### PR TITLE
feat: add Rockwood Clinical Frailty Scale models

### DIFF
--- a/models/olids/intermediate/observations/int_rockwood_all.sql
+++ b/models/olids/intermediate/observations/int_rockwood_all.sql
@@ -1,0 +1,79 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All Rockwood Clinical Frailty Scale observations from clinical records.
+Includes ALL persons (active, inactive, deceased).
+Captures Rockwood scores 1-9 with clinical categorisation.
+
+Rockwood Clinical Frailty Scale:
+- 1: Very Fit
+- 2: Well
+- 3: Managing Well
+- 4: Vulnerable
+- 5: Mildly Frail
+- 6: Moderately Frail
+- 7: Severely Frail
+- 8: Very Severely Frail
+- 9: Terminally Ill
+
+Clinical categorisation:
+- 1-3: Not Frail
+- 4: Vulnerable
+- 5-6: Frail
+- 7-9: Severely Frail
+*/
+
+WITH rockwood_mapping AS (
+    SELECT * FROM VALUES
+        ('1129331000000101', 1, 'Very Fit', 'Fit'),
+        ('1129341000000105', 2, 'Well', 'Fit'),
+        ('1129351000000108', 3, 'Managing Well', 'Fit'),
+        ('1129361000000106', 4, 'Vulnerable', 'Vulnerable'),
+        ('1129371000000104', 5, 'Mildly Frail', 'Mild Frailty'),
+        ('1129381000000102', 6, 'Moderately Frail', 'Moderate Frailty'),
+        ('1129391000000100', 7, 'Severely Frail', 'Severe Frailty'),
+        ('1129401000000102', 8, 'Very Severely Frail', 'Severe Frailty'),
+        ('1129411000000100', 9, 'Terminally Ill', 'Severe Frailty')
+    AS rockwood_lookup(concept_code, score, description, category)
+),
+
+base_observations AS (
+    SELECT
+        obs.observation_id,
+        obs.person_id,
+        obs.clinical_effective_date,
+        obs.mapped_concept_code AS concept_code,
+        obs.mapped_concept_display AS concept_display,
+        obs.cluster_id AS source_cluster_id
+    FROM ({{ get_observations("'ROCKWOOD_SCORES'") }}) obs
+    WHERE obs.clinical_effective_date IS NOT NULL
+      AND obs.clinical_effective_date <= CURRENT_DATE()
+)
+
+SELECT
+    bo.person_id,
+    bo.observation_id,
+    bo.clinical_effective_date,
+    bo.concept_code,
+    bo.concept_display,
+    bo.source_cluster_id,
+    
+    rm.score AS rockwood_score,
+    rm.description AS rockwood_description,
+    CONCAT('Level ', rm.score, ': ', rm.description) AS frailty_level,
+    rm.category AS frailty_category,
+    
+    -- Data quality flags
+    rm.concept_code IS NOT NULL AS is_valid_rockwood_code,
+    rm.score >= 5 AS is_frail,
+    rm.score >= 7 AS is_severely_frail
+
+FROM base_observations bo
+LEFT JOIN rockwood_mapping rm
+    ON bo.concept_code = rm.concept_code
+
+ORDER BY person_id, clinical_effective_date DESC

--- a/models/olids/intermediate/observations/int_rockwood_all.yml
+++ b/models/olids/intermediate/observations/int_rockwood_all.yml
@@ -1,0 +1,71 @@
+version: 2
+
+models:
+  - name: int_rockwood_all
+    description: 'Rockwood Clinical Frailty Scale assessments with clinical categorisation.
+
+      One row per Rockwood observation using ROCKWOOD_SCORES cluster with scores 1-9 mapped to frailty categories.'
+
+    tests:
+      - cluster_ids_exist:
+          arguments:
+            cluster_ids: ROCKWOOD_SCORES
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - observation_id
+              - source_cluster_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "rockwood_score IS NOT NULL"
+          name: all_rockwood_codes_categorised
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "frailty_category != 'Unknown'"
+          name: all_observations_have_valid_category
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - not_null
+
+      - name: observation_id
+        description: Identifier for the observation
+        tests:
+          - not_null
+
+      - name: clinical_effective_date
+        description: Date when the Rockwood assessment was performed
+        tests:
+          - not_null
+
+      - name: concept_code
+        description: SNOMED CT concept code for the specific Rockwood score
+
+      - name: concept_display
+        description: Human readable description of the Rockwood score
+
+      - name: source_cluster_id
+        description: Source cluster identifier (ROCKWOOD_SCORES)
+
+      - name: rockwood_score
+        description: Numeric Rockwood Clinical Frailty Scale score (1-9)
+
+      - name: rockwood_description
+        description: Clinical description of the Rockwood score level
+
+      - name: frailty_level
+        description: Specific Rockwood frailty level (Level 1-9 with description)
+
+      - name: frailty_category
+        description: Grouped frailty categories (Fit, Vulnerable, Mild Frailty, Moderate Frailty, Severe Frailty)
+
+      - name: is_valid_rockwood_code
+        description: Flag indicating if concept code is a valid Rockwood score
+
+      - name: is_frail
+        description: Flag for frailty presence (Rockwood score 5+)
+
+      - name: is_severely_frail
+        description: Flag for severe frailty (Rockwood score 7+)

--- a/models/olids/intermediate/observations/int_rockwood_latest.sql
+++ b/models/olids/intermediate/observations/int_rockwood_latest.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id']
+    )
+}}
+
+/*
+Latest Rockwood Clinical Frailty Scale score per person.
+Uses most recent assessment date, with observation_id as tiebreaker.
+*/
+
+SELECT
+    person_id,
+    observation_id,
+    clinical_effective_date,
+    concept_code,
+    concept_display,
+    source_cluster_id,
+    rockwood_score,
+    rockwood_description,
+    frailty_level,
+    frailty_category,
+    is_valid_rockwood_code,
+    is_frail,
+    is_severely_frail
+FROM {{ ref('int_rockwood_all') }}
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY person_id
+    ORDER BY clinical_effective_date DESC, observation_id DESC
+) = 1

--- a/models/olids/intermediate/observations/int_rockwood_latest.yml
+++ b/models/olids/intermediate/observations/int_rockwood_latest.yml
@@ -1,0 +1,60 @@
+version: 2
+
+models:
+  - name: int_rockwood_latest
+    description: 'Latest Rockwood Clinical Frailty Scale score per person.
+
+      One row per person with their most recent Rockwood assessment using latest clinical_effective_date.'
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - not_null
+          - unique
+
+      - name: observation_id
+        description: Identifier for the most recent Rockwood observation
+        tests:
+          - not_null
+
+      - name: clinical_effective_date
+        description: Date of the most recent Rockwood assessment
+        tests:
+          - not_null
+
+      - name: concept_code
+        description: SNOMED CT concept code for the latest Rockwood score
+
+      - name: concept_display
+        description: Human readable description of the latest Rockwood score
+
+      - name: source_cluster_id
+        description: Source cluster identifier (ROCKWOOD_SCORES)
+
+      - name: rockwood_score
+        description: Most recent numeric Rockwood Clinical Frailty Scale score (1-9)
+
+      - name: rockwood_description
+        description: Clinical description of the latest Rockwood score level
+
+      - name: frailty_level
+        description: Latest specific Rockwood frailty level (Level 1-9 with description)
+
+      - name: frailty_category
+        description: Latest grouped frailty category (Fit, Vulnerable, Mild Frailty, Moderate Frailty, Severe Frailty)
+
+      - name: is_valid_rockwood_code
+        description: Flag indicating if concept code is a valid Rockwood score
+
+      - name: is_frail
+        description: Flag indicating current frailty status (score 5+)
+
+      - name: is_severely_frail
+        description: Flag indicating current severe frailty status (score 7+)


### PR DESCRIPTION
## Summary
- Implements int_rockwood_all and int_rockwood_latest models for Rockwood Clinical Frailty Scale assessments
- Uses ROCKWOOD_SCORES cluster with scores 1-9 mapped to clinical categories
- Provides both specific frailty levels (Level 1-9) and grouped categories (Fit, Vulnerable, Mild/Moderate/Severe Frailty)

## Test plan
- [x] Models compile successfully
- [x] Data quality tests added for cluster existence and code mapping validation
- [x] Uses maintainable lookup table approach for easy future updates
- [x] dbt test to validate data quality constraints
- [x] Verify expected data volumes and categories

Closes #60