### PR TITLE
fix: correct model references and add connection info display

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -4,6 +4,10 @@ config-version: 2
 
 profile: 'dbt_olids'
 
+# Display connection info when dbt runs start
+on-run-start:
+  - "{{ log('🔗 DBT CONNECTION: Role=' ~ target.role ~ ', Warehouse=' ~ target.warehouse ~ ', Database=' ~ target.database ~ ', Schema=' ~ target.schema ~ ', Target=' ~ target.name, info=True) }}"
+
 target-path: "target"
 clean-targets:
   - "target"

--- a/models/olids/marts/organisation/dim_practice_neighbourhood.yml
+++ b/models/olids/marts/organisation/dim_practice_neighbourhood.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: dim_neighbourhood_registered
+  - name: dim_practice_neighbourhood
     description: 'Practice geographic context with local authority and neighbourhood classifications.
 
       Key Features:

--- a/models/shared/staging/schema.yml
+++ b/models/shared/staging/schema.yml
@@ -498,7 +498,7 @@ models:
   description: Staging model for reference pcd refset latest
   tests:
   - all_source_columns_in_staging
-- name: stg_reference_neighbourhood_registered_lookup
+- name: stg_reference_practice_neighbourhood_lookup
   description: Staging model for reference practice neighbourhood lookup
   tests:
   - all_source_columns_in_staging


### PR DESCRIPTION
## Summary
- Fix dim_practice_neighbourhood.yml to reference correct model name
- Fix shared staging schema.yml to use correct staging model name  
- Add on-run-start hook to display connection details (role, warehouse, database, schema)

## Details
Resolves test failures caused by incorrect model references in YAML files:
- `dim_neighbourhood_registered` → `dim_practice_neighbourhood` 
- `stg_reference_neighbourhood_registered_lookup` → `stg_reference_practice_neighbourhood_lookup`

Also adds connection info display when running dbt commands to show current role, warehouse, database, and schema.

## Test plan
- [x] Models reference correct names in YAML files
- [x] Connection info displays on dbt run
- [x] Pre-commit hooks pass