### PR TITLE
fix: use SNOWFLAKE_TARGET_DATABASE env var consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ models/olids/
 └── intermediate/   # NCL practices lookup
 ```
 
+## Where Objects Are Built
+
+All models are built in the database specified by `SNOWFLAKE_TARGET_DATABASE` in your `.env` file (typically `DATA_LAB_OLIDS_NCL`):
+
+- **Base layer**: `DATA_LAB_OLIDS_NCL.olids_base.*` (views)
+- **Stable layer**: `DATA_LAB_OLIDS_NCL.olids.*` (tables)
+- **Intermediate**: `DATA_LAB_OLIDS_NCL.DBT_STABLE.*` (tables)
+
+The stable layer reads from `Data_Store_OLIDS_Alpha` source tables.
+
 ## Contributing
 
 See [Contributing Guide](CONTRIBUTING.md) for workflow details.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,13 +34,13 @@ models:
     olids:
       base:
         +materialized: view
-        +database: "DATA_LAB_OLIDS_NCL"
+        +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}"
         +schema: "olids_base"
         +post-hook: ["{{ add_model_comment() }}"]
         +tags: ["base"]
       stable:
         +materialized: incremental
-        +database: "DATA_LAB_OLIDS_NCL"
+        +database: "{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}"
         +schema: "olids"
         +on_schema_change: fail
         +post-hook: ["{{ add_model_comment() }}"]


### PR DESCRIPTION
## Summary

Makes database configuration consistent by using `SNOWFLAKE_TARGET_DATABASE` environment variable throughout `dbt_project.yml` instead of hardcoded values.

## Changes

**dbt_project.yml:**
- Replaced hardcoded `DATA_LAB_OLIDS_NCL` with `{{ env_var('SNOWFLAKE_TARGET_DATABASE') }}` for base and stable layers
- Ensures all layers use the same configurable database

**README.md:**
- Added "Where Objects Are Built" section
- Documents database and schema locations for each layer
- Clarifies that stable layer reads from `Data_Store_OLIDS_Alpha`

## Benefits

- Single source of truth for target database configuration
- Easier to switch environments or databases
- Clear documentation of where dbt creates objects

## Test Plan

- [ ] Verify `dbt debug` connects successfully
- [ ] Run `dbt build` and confirm objects created in correct database/schemas
- [ ] Check base layer views in `{database}.olids_base`
- [ ] Check stable layer tables in `{database}.olids`