### PR TITLE
chore: extend QA scripts with additional completeness checks and diagnostic query

### DIFF
--- a/scripts/qa/check_data_completeness.py
+++ b/scripts/qa/check_data_completeness.py
@@ -22,10 +22,12 @@ ROLE = os.getenv('SNOWFLAKE_ROLE')
 # Format: (schema, table, field_name)
 COMPLETENESS_CHECKS = [
     # Patient table
+    ('OLIDS_MASKED', 'PATIENT', 'id'),
     ('OLIDS_MASKED', 'PATIENT', 'sk_patient_id'),
     ('OLIDS_MASKED', 'PATIENT', 'birth_year'),
     ('OLIDS_MASKED', 'PATIENT', 'birth_month'),
     ('OLIDS_MASKED', 'PATIENT', 'gender_concept_id'),
+    ('OLIDS_MASKED', 'PATIENT', 'lds_start_date_time'),
 
     # Episode of care
     ('OLIDS_COMMON', 'EPISODE_OF_CARE', 'id'),
@@ -37,6 +39,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'EPISODE_OF_CARE', 'episode_status_source_concept_id'),
 
     # Observation
+    ('OLIDS_COMMON', 'OBSERVATION', 'id'),
     ('OLIDS_COMMON', 'OBSERVATION', 'patient_id'),
     ('OLIDS_COMMON', 'OBSERVATION', 'person_id'),
     ('OLIDS_COMMON', 'OBSERVATION', 'lds_start_date_time'),
@@ -47,6 +50,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'OBSERVATION', 'episodicity_concept_id'),
 
     # Medication Statement
+    ('OLIDS_COMMON', 'MEDICATION_STATEMENT', 'id'),
     ('OLIDS_COMMON', 'MEDICATION_STATEMENT', 'patient_id'),
     ('OLIDS_COMMON', 'MEDICATION_STATEMENT', 'person_id'),
     ('OLIDS_COMMON', 'MEDICATION_STATEMENT', 'lds_start_date_time'),
@@ -56,6 +60,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'MEDICATION_STATEMENT', 'date_precision_concept_id'),
 
     # Medication Order
+    ('OLIDS_COMMON', 'MEDICATION_ORDER', 'id'),
     ('OLIDS_COMMON', 'MEDICATION_ORDER', 'patient_id'),
     ('OLIDS_COMMON', 'MEDICATION_ORDER', 'person_id'),
     ('OLIDS_COMMON', 'MEDICATION_ORDER', 'lds_start_date_time'),
@@ -64,6 +69,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'MEDICATION_ORDER', 'date_precision_concept_id'),
 
     # Diagnostic Order
+    ('OLIDS_COMMON', 'DIAGNOSTIC_ORDER', 'id'),
     ('OLIDS_COMMON', 'DIAGNOSTIC_ORDER', 'patient_id'),
     ('OLIDS_COMMON', 'DIAGNOSTIC_ORDER', 'person_id'),
     ('OLIDS_COMMON', 'DIAGNOSTIC_ORDER', 'lds_start_date_time'),
@@ -74,6 +80,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'DIAGNOSTIC_ORDER', 'episodicity_concept_id'),
 
     # Encounter
+    ('OLIDS_COMMON', 'ENCOUNTER', 'id'),
     ('OLIDS_COMMON', 'ENCOUNTER', 'patient_id'),
     ('OLIDS_COMMON', 'ENCOUNTER', 'person_id'),
     ('OLIDS_COMMON', 'ENCOUNTER', 'lds_start_date_time'),
@@ -82,6 +89,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'ENCOUNTER', 'date_precision_concept_id'),
 
     # Allergy Intolerance
+    ('OLIDS_COMMON', 'ALLERGY_INTOLERANCE', 'id'),
     ('OLIDS_COMMON', 'ALLERGY_INTOLERANCE', 'patient_id'),
     ('OLIDS_COMMON', 'ALLERGY_INTOLERANCE', 'person_id'),
     ('OLIDS_COMMON', 'ALLERGY_INTOLERANCE', 'lds_start_date_time'),
@@ -90,6 +98,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'ALLERGY_INTOLERANCE', 'date_precision_concept_id'),
 
     # Procedure Request
+    ('OLIDS_COMMON', 'PROCEDURE_REQUEST', 'id'),
     ('OLIDS_COMMON', 'PROCEDURE_REQUEST', 'lds_start_date_time'),
     ('OLIDS_COMMON', 'PROCEDURE_REQUEST', 'clinical_effective_date'),
     ('OLIDS_COMMON', 'PROCEDURE_REQUEST', 'procedure_request_source_concept_id'),
@@ -97,6 +106,7 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'PROCEDURE_REQUEST', 'status_concept_id'),
 
     # Referral Request
+    ('OLIDS_COMMON', 'REFERRAL_REQUEST', 'id'),
     ('OLIDS_COMMON', 'REFERRAL_REQUEST', 'lds_start_date_time'),
     ('OLIDS_COMMON', 'REFERRAL_REQUEST', 'clinical_effective_date'),
     ('OLIDS_COMMON', 'REFERRAL_REQUEST', 'referral_request_source_concept_id'),
@@ -106,21 +116,74 @@ COMPLETENESS_CHECKS = [
     ('OLIDS_COMMON', 'REFERRAL_REQUEST', 'referral_request_specialty_concept_id'),
 
     # Location Contact
+    ('OLIDS_COMMON', 'LOCATION_CONTACT', 'id'),
     ('OLIDS_COMMON', 'LOCATION_CONTACT', 'contact_type_concept_id'),
+    ('OLIDS_COMMON', 'LOCATION_CONTACT', 'lds_start_date_time'),
 
     # Appointment
+    ('OLIDS_COMMON', 'APPOINTMENT', 'id'),
     ('OLIDS_COMMON', 'APPOINTMENT', 'appointment_status_concept_id'),
     ('OLIDS_COMMON', 'APPOINTMENT', 'booking_method_concept_id'),
     ('OLIDS_COMMON', 'APPOINTMENT', 'contact_mode_concept_id'),
+    ('OLIDS_COMMON', 'APPOINTMENT', 'lds_start_date_time'),
+
+    # Appointment Practitioner
+    ('OLIDS_COMMON', 'APPOINTMENT_PRACTITIONER', 'id'),
+    ('OLIDS_COMMON', 'APPOINTMENT_PRACTITIONER', 'lds_start_date_time'),
+
+    # Patient Registered Practitioner In Role
+    ('OLIDS_COMMON', 'PATIENT_REGISTERED_PRACTITIONER_IN_ROLE', 'id'),
+    ('OLIDS_COMMON', 'PATIENT_REGISTERED_PRACTITIONER_IN_ROLE', 'lds_start_date_time'),
+
+    # Location
+    ('OLIDS_COMMON', 'LOCATION', 'id'),
+    ('OLIDS_COMMON', 'LOCATION', 'lds_start_date_time'),
 
     # Flag
+    ('OLIDS_COMMON', 'FLAG', 'id'),
     ('OLIDS_COMMON', 'FLAG', 'lds_start_date_time'),
 
     # Patient Address
+    ('OLIDS_MASKED', 'PATIENT_ADDRESS', 'id'),
     ('OLIDS_MASKED', 'PATIENT_ADDRESS', 'address_type_concept_id'),
+    ('OLIDS_MASKED', 'PATIENT_ADDRESS', 'lds_start_date_time'),
 
     # Patient Contact
+    ('OLIDS_MASKED', 'PATIENT_CONTACT', 'id'),
     ('OLIDS_MASKED', 'PATIENT_CONTACT', 'contact_type_concept_id'),
+    ('OLIDS_MASKED', 'PATIENT_CONTACT', 'lds_start_date_time'),
+
+    # Patient UPRN
+    ('OLIDS_MASKED', 'PATIENT_UPRN', 'id'),
+    ('OLIDS_MASKED', 'PATIENT_UPRN', 'lds_start_date_time'),
+
+    # Organisation
+    ('OLIDS_COMMON', 'ORGANISATION', 'id'),
+    ('OLIDS_COMMON', 'ORGANISATION', 'lds_start_date_time'),
+
+    # Practitioner
+    ('OLIDS_COMMON', 'PRACTITIONER', 'id'),
+    ('OLIDS_COMMON', 'PRACTITIONER', 'lds_start_date_time'),
+
+    # Practitioner In Role
+    ('OLIDS_COMMON', 'PRACTITIONER_IN_ROLE', 'id'),
+    ('OLIDS_COMMON', 'PRACTITIONER_IN_ROLE', 'lds_start_date_time'),
+
+    # Schedule
+    ('OLIDS_COMMON', 'SCHEDULE', 'id'),
+    ('OLIDS_COMMON', 'SCHEDULE', 'lds_start_date_time'),
+
+    # Schedule Practitioner
+    ('OLIDS_COMMON', 'SCHEDULE_PRACTITIONER', 'id'),
+    ('OLIDS_COMMON', 'SCHEDULE_PRACTITIONER', 'lds_start_date_time'),
+
+    # Concept
+    ('OLIDS_TERMINOLOGY', 'CONCEPT', 'id'),
+    ('OLIDS_TERMINOLOGY', 'CONCEPT', 'lds_start_date_time'),
+
+    # Concept Map
+    ('OLIDS_TERMINOLOGY', 'CONCEPT_MAP', 'id'),
+    ('OLIDS_TERMINOLOGY', 'CONCEPT_MAP', 'lds_start_date_time'),
 ]
 
 

--- a/scripts/qa/compare_registration_counts.py
+++ b/scripts/qa/compare_registration_counts.py
@@ -15,7 +15,7 @@ load_dotenv()
 OLIDS_DATABASE = '"Data_Store_OLIDS_Alpha"'
 PDS_DATABASE = '"Data_Store_Registries"'
 DICTIONARY_DATABASE = '"Dictionary"'
-TARGET_DATE = '2025-09-01'
+TARGET_DATE = '2025-10-20'
 WAREHOUSE = os.getenv('SNOWFLAKE_WAREHOUSE')
 ACCOUNT = os.getenv('SNOWFLAKE_ACCOUNT')
 USER = os.getenv('SNOWFLAKE_USER')
@@ -95,7 +95,6 @@ def get_olids_registrations(session):
         SELECT DISTINCT c.id AS concept_id
         FROM {OLIDS_DATABASE}.OLIDS_TERMINOLOGY.CONCEPT c
         WHERE c.code = '24531000000104'  -- Registration type
-            AND c.display = 'Registration type'
     ),
 
     patient_episodes AS (

--- a/scripts/qa/find_missing_lds_record_ids.sql
+++ b/scripts/qa/find_missing_lds_record_ids.sql
@@ -1,0 +1,229 @@
+-- Find lds_record_id values that exist in Clinical_Validation but not in Alpha
+-- Returns up to 100 examples per table to support investigation
+USE ROLE "ISL-USERGROUP-SECONDEES-NCL";
+
+SELECT * FROM (
+    SELECT 'ALLERGY_INTOLERANCE' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.ALLERGY_INTOLERANCE cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'APPOINTMENT' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.APPOINTMENT cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.APPOINTMENT a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'APPOINTMENT_PRACTITIONER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.APPOINTMENT_PRACTITIONER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.APPOINTMENT_PRACTITIONER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'DIAGNOSTIC_ORDER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.DIAGNOSTIC_ORDER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.DIAGNOSTIC_ORDER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'ENCOUNTER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.ENCOUNTER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'EPISODE_OF_CARE' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.EPISODE_OF_CARE cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'FLAG' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.FLAG cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.FLAG a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'LOCATION' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.LOCATION cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.LOCATION a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'LOCATION_CONTACT' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.LOCATION_CONTACT cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.LOCATION_CONTACT a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'MEDICATION_ORDER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.MEDICATION_ORDER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'MEDICATION_STATEMENT' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.MEDICATION_STATEMENT cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'OBSERVATION' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.OBSERVATION cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'ORGANISATION' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.ORGANISATION cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ORGANISATION a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PATIENT' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_MASKED.PATIENT cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PATIENT_ADDRESS' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_MASKED.PATIENT_ADDRESS cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT_ADDRESS a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PATIENT_CONTACT' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_MASKED.PATIENT_CONTACT cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT_CONTACT a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PATIENT_REGISTERED_PRACTITIONER_IN_ROLE' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.PATIENT_REGISTERED_PRACTITIONER_IN_ROLE cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PATIENT_REGISTERED_PRACTITIONER_IN_ROLE a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PATIENT_UPRN' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_MASKED.PATIENT_UPRN cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT_UPRN a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PERSON' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_MASKED.PERSON cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PERSON a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PRACTITIONER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.PRACTITIONER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PRACTITIONER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PRACTITIONER_IN_ROLE' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.PRACTITIONER_IN_ROLE cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PRACTITIONER_IN_ROLE a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'PROCEDURE_REQUEST' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.PROCEDURE_REQUEST cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PROCEDURE_REQUEST a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'REFERRAL_REQUEST' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.REFERRAL_REQUEST cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.REFERRAL_REQUEST a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'SCHEDULE' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.SCHEDULE cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.SCHEDULE a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+UNION ALL
+SELECT * FROM (
+    SELECT 'SCHEDULE_PRACTITIONER' AS table_name, cv."lds_record_id"
+    FROM "Data_Store_OLIDS_Clinical_Validation".OLIDS_COMMON.SCHEDULE_PRACTITIONER cv
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.SCHEDULE_PRACTITIONER a
+        ON a.lds_record_id = cv."lds_record_id"
+    WHERE a.lds_record_id IS NULL
+    LIMIT 100
+)
+ORDER BY table_name, "lds_record_id";


### PR DESCRIPTION
## Summary
- Extended completeness checks to include `id` and `lds_start_date_time` fields across all OLIDS tables
- Updated target date in registration comparison from 2025-09-01 to 2025-10-20
- Removed unnecessary display filter from registration type concept query
- Added SQL query to identify missing `lds_record_id` values between Clinical_Validation and Alpha environments

## Changes
**scripts/qa/check_data_completeness.py**
- Added `id` field checks for all tables in OLIDS_COMMON, OLIDS_MASKED, and OLIDS_TERMINOLOGY schemas
- Added `lds_start_date_time` field checks across all relevant tables
- Added completeness checks for previously uncovered tables: APPOINTMENT_PRACTITIONER, PATIENT_REGISTERED_PRACTITIONER_IN_ROLE, LOCATION, PATIENT_UPRN, ORGANISATION, PRACTITIONER, PRACTITIONER_IN_ROLE, SCHEDULE, SCHEDULE_PRACTITIONER, CONCEPT, and CONCEPT_MAP

**scripts/qa/compare_registration_counts.py**
- Updated `TARGET_DATE` from '2025-09-01' to '2025-10-20'
- Removed redundant `display` filter from registration type concept query

**scripts/qa/find_missing_lds_record_ids.sql** (new)
- Identifies `lds_record_id` values present in Clinical_Validation but missing from Alpha environment
- Checks 25 tables across OLIDS_COMMON, OLIDS_MASKED schemas
- Returns up to 100 examples per table to support investigation

## Test Plan
- [x] Run `check_data_completeness.py` script to verify expanded checks
- [x] Run `compare_registration_counts.py` with updated target date
- [x] Execute `find_missing_lds_record_ids.sql` in Snowflake to identify discrepancies