### PR TITLE
feat: add POSTCODE_HASH reference table and update clone databases

### DIFF
--- a/models/olids/base/base_olids_postcode_hash.sql
+++ b/models/olids/base/base_olids_postcode_hash.sql
@@ -1,0 +1,23 @@
+/*
+POSTCODE_HASH Base View
+OLIDS reference data linking postcode hashes to geographical areas.
+Passthrough view with standard column naming applied.
+*/
+
+SELECT
+    id,
+    postcode_hash,
+    primary_care_organisation,
+    local_authority_organisation,
+    yr2011_lsoa,
+    yr2011_msoa,
+    yr2021_lsoa,
+    yr2021_msoa,
+    effective_from,
+    effective_to,
+    is_latest,
+    lds_is_deleted,
+    lds_start_date_time,
+    lakehousedateprocessed,
+    high_watermark_date_time
+FROM {{ source('olids_reference', 'POSTCODE_HASH') }}

--- a/models/olids/base/schema.yml
+++ b/models/olids/base/schema.yml
@@ -327,3 +327,10 @@ models:
     No filters applied - reference data used as-is.
 
     Direct passthrough from source table with explicit column selection for interface consistency.'
+- name: base_olids_postcode_hash
+  description: 'Unfiltered postcode hash reference view linking postcodes to geographical areas.
+
+
+    No filters applied - reference data used as-is.
+
+    Direct passthrough from source table with explicit column selection for interface consistency.'

--- a/models/olids/stable/schema.yml
+++ b/models/olids/stable/schema.yml
@@ -196,3 +196,10 @@ models:
     Provides stable interface between source data and analytical models.
 
     Uses incremental materialisation for efficient updates.'
+- name: stable_postcode_hash
+  description: 'Incremental postcode hash table linking postcodes to geographical areas.
+
+
+    Provides stable interface between source data and analytical models.
+
+    Uses incremental materialisation for efficient updates.'

--- a/models/olids/stable/stable_postcode_hash.sql
+++ b/models/olids/stable/stable_postcode_hash.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='fail',
+        cluster_by=['id', 'postcode_hash'],
+        alias='postcode_hash',
+        incremental_strategy='merge',
+        tags=['stable', 'incremental']
+    )
+}}
+
+select
+    id,
+    postcode_hash,
+    primary_care_organisation,
+    local_authority_organisation,
+    yr2011_lsoa,
+    yr2011_msoa,
+    yr2021_lsoa,
+    yr2021_msoa,
+    effective_from,
+    effective_to,
+    is_latest,
+    lds_is_deleted,
+    lds_start_date_time,
+    lakehousedateprocessed,
+    high_watermark_date_time
+from {{ ref('base_olids_postcode_hash') }}
+
+{% if is_incremental() %}
+    where lds_start_date_time > (select max(lds_start_date_time) from {{ this }})
+{% endif %}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -1374,6 +1374,44 @@ sources:
       data_type: TEXT
     - name: lds_lakehouse_datetime_updated
       data_type: TIMESTAMP_NTZ
+- name: olids_reference
+  database: '"Data_Store_OLIDS_Alpha"'
+  schema: '"OLIDS_REFERENCE"'
+  description: OLIDS reference data including postcode lookups
+  tables:
+  - name: POSTCODE_HASH
+    identifier: '"POSTCODE_HASH"'
+    columns:
+    - name: ID
+      data_type: BINARY
+    - name: POSTCODE_HASH
+      data_type: BINARY
+    - name: PRIMARY_CARE_ORGANISATION
+      data_type: TEXT
+    - name: LOCAL_AUTHORITY_ORGANISATION
+      data_type: TEXT
+    - name: YR2011_LSOA
+      data_type: TEXT
+    - name: YR2011_MSOA
+      data_type: TEXT
+    - name: YR2021_LSOA
+      data_type: TEXT
+    - name: YR2021_MSOA
+      data_type: TEXT
+    - name: EFFECTIVE_FROM
+      data_type: TIMESTAMP_NTZ
+    - name: EFFECTIVE_TO
+      data_type: TIMESTAMP_NTZ
+    - name: IS_LATEST
+      data_type: NUMBER
+    - name: LDS_IS_DELETED
+      data_type: BOOLEAN
+    - name: LDS_START_DATE_TIME
+      data_type: TIMESTAMP_NTZ
+    - name: LAKEHOUSEDATEPROCESSED
+      data_type: DATE
+    - name: HIGH_WATERMARK_DATE_TIME
+      data_type: TIMESTAMP_NTZ
 - name: olids_terminology
   database: '"Data_Store_OLIDS_Alpha"'
   schema: '"OLIDS_TERMINOLOGY"'

--- a/scripts/tests/check_table_dml_timestamps.sql
+++ b/scripts/tests/check_table_dml_timestamps.sql
@@ -19,9 +19,10 @@ FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
 WHERE database_name IN (
         'DATA_LAB_OLIDS_NCL',
         'Data_Store_OLIDS_Alpha',
+        'Data_Store_OLIDS_Alpha_Clone_19092025',
         'Data_Store_OLIDS_Alpha_Clone_06102025',
         'Data_Store_OLIDS_Alpha_Clone_15102025',
-        'Data_Store_OLIDS_Alpha_Clone_19092025',
+        'Data_Store_OLIDS_Alpha_Clone_31102025',
         'Data_Store_OLIDS_Clinical_Validation',
         'Data_Store_OLIDS_Dummy',
         'Data_Store_OLIDS_UAT'

--- a/scripts/tests/compare_row_counts.sql
+++ b/scripts/tests/compare_row_counts.sql
@@ -24,6 +24,16 @@ WITH all_rowcounts AS (
     UNION ALL
 
     SELECT
+        'Data_Store_OLIDS_Alpha_Clone_19092025' AS database_name,
+        table_name,
+        row_count
+    FROM "Data_Store_OLIDS_Alpha_Clone_19092025".INFORMATION_SCHEMA.TABLES
+    WHERE table_type = 'BASE TABLE'
+        AND table_name NOT LIKE '%_BACKUP'
+
+    UNION ALL
+
+    SELECT
         'Data_Store_OLIDS_Alpha_Clone_06102025' AS database_name,
         table_name,
         row_count
@@ -44,10 +54,10 @@ WITH all_rowcounts AS (
     UNION ALL
 
     SELECT
-        'Data_Store_OLIDS_Alpha_Clone_19092025' AS database_name,
+        'Data_Store_OLIDS_Alpha_Clone_31102025' AS database_name,
         table_name,
         row_count
-    FROM "Data_Store_OLIDS_Alpha_Clone_19092025".INFORMATION_SCHEMA.TABLES
+    FROM "Data_Store_OLIDS_Alpha_Clone_31102025".INFORMATION_SCHEMA.TABLES
     WHERE table_type = 'BASE TABLE'
         AND table_name NOT LIKE '%_BACKUP'
 
@@ -96,9 +106,10 @@ SELECT
     table_name,
     MAX(CASE WHEN database_name = 'Stable' THEN formatted_count END) AS "Stable",
     MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha' THEN formatted_count END) AS "Alpha",
-    MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_15102025' THEN formatted_count END) AS "Clone_15102025",
-    MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_06102025' THEN formatted_count END) AS "Clone_06102025",
     MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_19092025' THEN formatted_count END) AS "Clone_19092025",
+    MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_06102025' THEN formatted_count END) AS "Clone_06102025",
+    MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_15102025' THEN formatted_count END) AS "Clone_15102025",
+    MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Alpha_Clone_31102025' THEN formatted_count END) AS "Clone_31102025",
     MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Clinical_Validation' THEN formatted_count END) AS "Clinical_Validation",
     MAX(CASE WHEN database_name = 'Data_Store_OLIDS_UAT' THEN formatted_count END) AS "UAT",
     MAX(CASE WHEN database_name = 'Data_Store_OLIDS_Dummy' THEN formatted_count END) AS "Dummy"


### PR DESCRIPTION
## Summary
- Add OLIDS_REFERENCE schema with POSTCODE_HASH table for linking postcode hashes to geographical areas, which was previously omitted.
- Create base and stable layer models for POSTCODE_HASH as 1:1 passthrough (no filtering needed as it's just a reference table), the table already exists in the OLIDS schema, this change just ensures it is updated.
- Update clone database references to include Data_Store_OLIDS_Alpha_Clone_31102025

## Changes
### New Models
- `base_olids_postcode_hash` - Passthrough view from olids_reference.POSTCODE_HASH
- `stable_postcode_hash` - Incremental table with clustering on id and postcode_hash

### Updated Files
- `models/sources.yml` - Added olids_reference schema with POSTCODE_HASH table definition
- `models/olids/base/schema.yml` - Added documentation for base_olids_postcode_hash
- `models/olids/stable/schema.yml` - Added documentation for stable_postcode_hash
- `scripts/tests/check_table_dml_timestamps.sql` - Added Clone_31102025 and reordered chronologically
- `scripts/tests/compare_row_counts.sql` - Added Clone_31102025 and reordered chronologically

## Usage
The POSTCODE_HASH table is used joined to PATIENT_ADDRESS using the postcode_hash column to enrich patient address data with geographical information.

## Test Plan
- [ ] Run dbt to verify models compile
- [ ] Test incremental build for stable_postcode_hash