### PR TITLE
feat: add native SQL test scripts with Python runner

### DIFF
--- a/scripts/tests/run_tests.py
+++ b/scripts/tests/run_tests.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+OLIDS Test Runner
+
+Discovers and executes all test_*.sql files in the same directory.
+Produces a summary report with PASS/FAIL counts and details.
+
+Usage:
+    python run_tests.py
+    python run_tests.py --test test_data_freshness.sql
+    python run_tests.py --verbose
+"""
+
+import os
+import sys
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# Try to import snowflake connector
+try:
+    from snowflake.snowpark import Session
+    USE_SNOWPARK = True
+except ImportError:
+    try:
+        import snowflake.connector
+        USE_SNOWPARK = False
+    except ImportError:
+        print("ERROR: Neither snowflake-snowpark-python nor snowflake-connector-python installed")
+        sys.exit(1)
+
+
+# Configuration from environment
+WAREHOUSE = os.getenv('SNOWFLAKE_WAREHOUSE')
+ACCOUNT = os.getenv('SNOWFLAKE_ACCOUNT')
+USER = os.getenv('SNOWFLAKE_USER')
+ROLE = os.getenv('SNOWFLAKE_ROLE')
+
+
+def get_connection():
+    """Create Snowflake connection using SSO."""
+    connection_params = {
+        "account": ACCOUNT,
+        "user": USER,
+        "authenticator": "externalbrowser",
+        "warehouse": WAREHOUSE,
+        "role": ROLE
+    }
+    
+    if USE_SNOWPARK:
+        return Session.builder.configs(connection_params).create()
+    else:
+        return snowflake.connector.connect(**connection_params)
+
+
+def discover_tests(test_dir: Path, specific_test: str = None) -> list:
+    """Find all test_*.sql files in the directory."""
+    if specific_test:
+        test_file = test_dir / specific_test
+        if test_file.exists():
+            return [test_file]
+        else:
+            print(f"ERROR: Test file not found: {specific_test}")
+            sys.exit(1)
+    
+    tests = sorted(test_dir.glob("test_*.sql"))
+    return tests
+
+
+def execute_test(conn, sql_file: Path) -> list:
+    """Execute a test SQL file and return results."""
+    sql = sql_file.read_text(encoding='utf-8')
+    
+    if USE_SNOWPARK:
+        # Snowpark returns a DataFrame
+        df = conn.sql(sql).to_pandas()
+        return df.to_dict('records')
+    else:
+        # Connector returns cursor
+        cursor = conn.cursor()
+        try:
+            # Execute multi-statement SQL
+            for statement in sql.split(';'):
+                statement = statement.strip()
+                if statement and not statement.startswith('--'):
+                    cursor.execute(statement)
+            
+            # Fetch results from last query
+            columns = [desc[0] for desc in cursor.description] if cursor.description else []
+            rows = cursor.fetchall()
+            return [dict(zip(columns, row)) for row in rows]
+        finally:
+            cursor.close()
+
+
+def print_results(all_results: dict, verbose: bool = False):
+    """Print formatted test results to console."""
+    total_tests = 0
+    total_pass = 0
+    total_fail = 0
+    total_warn = 0
+    
+    print("\n" + "=" * 80)
+    print("OLIDS DATA QUALITY TEST RESULTS")
+    print("=" * 80)
+    print(f"Execution time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print()
+    
+    for test_file, results in all_results.items():
+        if not results:
+            print(f"\n⚠️  {test_file}: No results returned")
+            continue
+        
+        # Count by status
+        pass_count = sum(1 for r in results if r.get('STATUS') == 'PASS')
+        fail_count = sum(1 for r in results if r.get('STATUS') == 'FAIL')
+        warn_count = sum(1 for r in results if r.get('STATUS') == 'WARN')
+        
+        total_tests += len(results)
+        total_pass += pass_count
+        total_fail += fail_count
+        total_warn += warn_count
+        
+        # Test header
+        status_emoji = "✅" if fail_count == 0 else "❌"
+        print(f"\n{status_emoji} {test_file}")
+        print(f"   PASS: {pass_count} | FAIL: {fail_count}" + (f" | WARN: {warn_count}" if warn_count else ""))
+        
+        # Show failures
+        failures = [r for r in results if r.get('STATUS') == 'FAIL']
+        if failures:
+            print("\n   Failures:")
+            for f in failures:
+                table = f.get('TABLE_NAME', 'N/A')
+                subject = f.get('TEST_SUBJECT', 'N/A')
+                metric = f.get('METRIC_VALUE', 'N/A')
+                threshold = f.get('THRESHOLD', 'N/A')
+                print(f"   - {table}.{subject}: {metric}% (threshold: {threshold}%)")
+                
+                if verbose:
+                    details = f.get('DETAILS', '{}')
+                    if isinstance(details, str):
+                        try:
+                            details = json.loads(details)
+                        except:
+                            pass
+                    if isinstance(details, dict):
+                        for k, v in details.items():
+                            print(f"       {k}: {v}")
+        
+        # Show warnings
+        warnings = [r for r in results if r.get('STATUS') == 'WARN']
+        if warnings and verbose:
+            print("\n   Warnings:")
+            for w in warnings:
+                table = w.get('TABLE_NAME', 'N/A')
+                subject = w.get('TEST_SUBJECT', 'N/A')
+                print(f"   - {table}.{subject}")
+    
+    # Summary
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"Total checks: {total_tests}")
+    print(f"Passed: {total_pass} ({100*total_pass/total_tests:.1f}%)" if total_tests else "Passed: 0")
+    print(f"Failed: {total_fail} ({100*total_fail/total_tests:.1f}%)" if total_tests else "Failed: 0")
+    if total_warn:
+        print(f"Warnings: {total_warn}")
+    
+    overall = "✅ ALL TESTS PASSED" if total_fail == 0 else f"❌ {total_fail} TESTS FAILED"
+    print(f"\n{overall}")
+    print("=" * 80)
+    
+    return total_fail == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run OLIDS data quality tests')
+    parser.add_argument('--test', '-t', help='Run specific test file only')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Show detailed output')
+    args = parser.parse_args()
+    
+    # Find tests
+    test_dir = Path(__file__).parent
+    tests = discover_tests(test_dir, args.test)
+    
+    if not tests:
+        print("No test files found (test_*.sql)")
+        sys.exit(1)
+    
+    print(f"Found {len(tests)} test file(s)")
+    for t in tests:
+        print(f"  - {t.name}")
+    
+    # Connect to Snowflake
+    print("\nConnecting to Snowflake...")
+    try:
+        conn = get_connection()
+        print("✓ Connected successfully")
+    except Exception as e:
+        print(f"ERROR: Failed to connect: {e}")
+        sys.exit(1)
+    
+    # Execute tests
+    all_results = {}
+    try:
+        for test_file in tests:
+            print(f"\nExecuting: {test_file.name}...")
+            try:
+                results = execute_test(conn, test_file)
+                all_results[test_file.name] = results
+                print(f"  → {len(results)} checks completed")
+            except Exception as e:
+                print(f"  → ERROR: {e}")
+                all_results[test_file.name] = []
+    finally:
+        if USE_SNOWPARK:
+            conn.close()
+        else:
+            conn.close()
+        print("\nConnection closed")
+    
+    # Print results
+    all_passed = print_results(all_results, verbose=args.verbose)
+    
+    # Exit code
+    sys.exit(0 if all_passed else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_column_completeness.sql
+++ b/scripts/tests/test_column_completeness.sql
@@ -1,0 +1,183 @@
+/*
+    Test: Column Completeness
+    
+    Checks NULL rates for critical fields across OLIDS tables.
+    
+    Configuration:
+    - NULL_THRESHOLD_PCT: Maximum allowed NULL percentage (default: 1.0)
+    
+    Returns standardised test results with PASS/FAIL status.
+*/
+
+-- ============================================
+-- CONFIGURATION - Edit threshold here
+-- ============================================
+SET null_threshold_pct = 1.0;  -- Default 1% - columns with > 1% NULLs will FAIL
+
+-- ============================================
+-- TEST EXECUTION
+-- ============================================
+WITH patient_checks AS (
+    SELECT
+        'PATIENT' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT
+        UNION ALL
+        SELECT 'sk_patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN sk_patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT
+        UNION ALL
+        SELECT 'birth_year', $null_threshold_pct, COUNT(*), SUM(CASE WHEN birth_year IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT
+        UNION ALL
+        SELECT 'birth_month', $null_threshold_pct, COUNT(*), SUM(CASE WHEN birth_month IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT
+        UNION ALL
+        SELECT 'gender_concept_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN gender_concept_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT
+    )
+),
+
+observation_checks AS (
+    SELECT
+        'OBSERVATION' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+        UNION ALL
+        SELECT 'person_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN person_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+        UNION ALL
+        SELECT 'clinical_effective_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN clinical_effective_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+        UNION ALL
+        SELECT 'observation_source_concept_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN observation_source_concept_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+    )
+),
+
+encounter_checks AS (
+    SELECT
+        'ENCOUNTER' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER
+        UNION ALL
+        SELECT 'person_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN person_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER
+        UNION ALL
+        SELECT 'clinical_effective_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN clinical_effective_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER
+    )
+),
+
+medication_order_checks AS (
+    SELECT
+        'MEDICATION_ORDER' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER
+        UNION ALL
+        SELECT 'person_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN person_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER
+        UNION ALL
+        SELECT 'clinical_effective_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN clinical_effective_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER
+    )
+),
+
+medication_statement_checks AS (
+    SELECT
+        'MEDICATION_STATEMENT' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT
+        UNION ALL
+        SELECT 'person_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN person_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT
+        UNION ALL
+        SELECT 'clinical_effective_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN clinical_effective_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT
+    )
+),
+
+episode_of_care_checks AS (
+    SELECT
+        'EPISODE_OF_CARE' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE
+        UNION ALL
+        SELECT 'person_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN person_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE
+        UNION ALL
+        SELECT 'episode_of_care_start_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN episode_of_care_start_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE
+    )
+),
+
+allergy_intolerance_checks AS (
+    SELECT
+        'ALLERGY_INTOLERANCE' AS table_name,
+        column_name,
+        threshold,
+        total_rows,
+        null_count,
+        ROUND(100.0 * null_count / NULLIF(total_rows, 0), 4) AS null_pct
+    FROM (
+        SELECT 'id' AS column_name, 0.0 AS threshold, COUNT(*) AS total_rows, SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) AS null_count FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE
+        UNION ALL
+        SELECT 'patient_id', $null_threshold_pct, COUNT(*), SUM(CASE WHEN patient_id IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE
+        UNION ALL
+        SELECT 'clinical_effective_date', $null_threshold_pct, COUNT(*), SUM(CASE WHEN clinical_effective_date IS NULL THEN 1 ELSE 0 END) FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE
+    )
+),
+
+all_checks AS (
+    SELECT * FROM patient_checks
+    UNION ALL SELECT * FROM observation_checks
+    UNION ALL SELECT * FROM encounter_checks
+    UNION ALL SELECT * FROM medication_order_checks
+    UNION ALL SELECT * FROM medication_statement_checks
+    UNION ALL SELECT * FROM episode_of_care_checks
+    UNION ALL SELECT * FROM allergy_intolerance_checks
+)
+
+SELECT
+    'column_completeness' AS test_name,
+    table_name,
+    column_name AS test_subject,
+    CASE 
+        WHEN null_pct <= threshold THEN 'PASS'
+        ELSE 'FAIL'
+    END AS status,
+    ROUND(100.0 - null_pct, 2) AS metric_value,  -- Completeness percentage
+    ROUND(100.0 - threshold, 2) AS threshold,     -- Required completeness
+    OBJECT_CONSTRUCT(
+        'total_rows', total_rows,
+        'null_count', null_count,
+        'null_percentage', null_pct,
+        'completeness_percentage', ROUND(100.0 - null_pct, 2),
+        'threshold_null_pct', threshold
+    )::VARCHAR AS details
+FROM all_checks
+ORDER BY status DESC, null_pct DESC, table_name, column_name;

--- a/scripts/tests/test_concept_mapping.sql
+++ b/scripts/tests/test_concept_mapping.sql
@@ -1,0 +1,167 @@
+/*
+    Test: Concept Mapping Integrity
+    
+    Validates that concept_id fields correctly map through:
+    concept_id → CONCEPT_MAP.source_code_id → CONCEPT_MAP.target_code_id → CONCEPT.id
+    
+    Returns standardised test results with PASS/FAIL status.
+    Threshold: 100% mapping required (any unmapped = FAIL)
+*/
+
+WITH observation_obs_src AS (
+    SELECT
+        'OBSERVATION' AS table_name,
+        'observation_source_concept_id' AS concept_field,
+        COUNT(DISTINCT base.observation_source_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.observation_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.observation_source_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.observation_source_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.observation_source_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.observation_source_concept_id IS NOT NULL
+),
+
+observation_units AS (
+    SELECT
+        'OBSERVATION' AS table_name,
+        'result_value_units_concept_id' AS concept_field,
+        COUNT(DISTINCT base.result_value_units_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.result_value_units_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.result_value_units_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.result_value_units_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.result_value_units_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.result_value_units_concept_id IS NOT NULL
+),
+
+observation_precision AS (
+    SELECT
+        'OBSERVATION' AS table_name,
+        'date_precision_concept_id' AS concept_field,
+        COUNT(DISTINCT base.date_precision_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.date_precision_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.date_precision_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.date_precision_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.date_precision_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.date_precision_concept_id IS NOT NULL
+),
+
+observation_episodicity AS (
+    SELECT
+        'OBSERVATION' AS table_name,
+        'episodicity_concept_id' AS concept_field,
+        COUNT(DISTINCT base.episodicity_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.episodicity_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.episodicity_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.episodicity_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.episodicity_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.episodicity_concept_id IS NOT NULL
+),
+
+medication_statement_src AS (
+    SELECT
+        'MEDICATION_STATEMENT' AS table_name,
+        'medication_statement_source_concept_id' AS concept_field,
+        COUNT(DISTINCT base.medication_statement_source_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.medication_statement_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.medication_statement_source_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.medication_statement_source_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.medication_statement_source_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.medication_statement_source_concept_id IS NOT NULL
+),
+
+medication_order_src AS (
+    SELECT
+        'MEDICATION_ORDER' AS table_name,
+        'medication_order_source_concept_id' AS concept_field,
+        COUNT(DISTINCT base.medication_order_source_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.medication_order_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.medication_order_source_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.medication_order_source_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.medication_order_source_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.medication_order_source_concept_id IS NOT NULL
+),
+
+encounter_src AS (
+    SELECT
+        'ENCOUNTER' AS table_name,
+        'encounter_source_concept_id' AS concept_field,
+        COUNT(DISTINCT base.encounter_source_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.encounter_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.encounter_source_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.encounter_source_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.encounter_source_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.encounter_source_concept_id IS NOT NULL
+),
+
+allergy_src AS (
+    SELECT
+        'ALLERGY_INTOLERANCE' AS table_name,
+        'allergy_intolerance_source_concept_id' AS concept_field,
+        COUNT(DISTINCT base.allergy_intolerance_source_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.allergy_intolerance_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.allergy_intolerance_source_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.allergy_intolerance_source_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.allergy_intolerance_source_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.allergy_intolerance_source_concept_id IS NOT NULL
+),
+
+patient_gender AS (
+    SELECT
+        'PATIENT' AS table_name,
+        'gender_concept_id' AS concept_field,
+        COUNT(DISTINCT base.gender_concept_id) AS total_distinct,
+        SUM(CASE WHEN base.gender_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows,
+        COUNT(DISTINCT CASE WHEN cm.source_code_id IS NULL THEN base.gender_concept_id END) AS unmapped_concepts,
+        SUM(CASE WHEN base.gender_concept_id IS NOT NULL AND cm.source_code_id IS NULL THEN 1 ELSE 0 END) AS unmapped_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT base
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT_MAP cm ON base.gender_concept_id = cm.source_code_id
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_TERMINOLOGY.CONCEPT c ON cm.target_code_id = c.id
+    WHERE base.gender_concept_id IS NOT NULL
+),
+
+all_results AS (
+    SELECT * FROM observation_obs_src
+    UNION ALL SELECT * FROM observation_units
+    UNION ALL SELECT * FROM observation_precision
+    UNION ALL SELECT * FROM observation_episodicity
+    UNION ALL SELECT * FROM medication_statement_src
+    UNION ALL SELECT * FROM medication_order_src
+    UNION ALL SELECT * FROM encounter_src
+    UNION ALL SELECT * FROM allergy_src
+    UNION ALL SELECT * FROM patient_gender
+)
+
+SELECT
+    'concept_mapping' AS test_name,
+    table_name,
+    concept_field AS test_subject,
+    CASE 
+        WHEN unmapped_concepts = 0 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS status,
+    ROUND(100.0 * (total_distinct - unmapped_concepts) / NULLIF(total_distinct, 0), 2) AS metric_value,
+    100.0 AS threshold,
+    OBJECT_CONSTRUCT(
+        'total_distinct_concepts', total_distinct,
+        'total_rows', total_rows,
+        'unmapped_concepts', unmapped_concepts,
+        'unmapped_rows', unmapped_rows,
+        'mapped_percentage', ROUND(100.0 * (total_distinct - unmapped_concepts) / NULLIF(total_distinct, 0), 2)
+    )::VARCHAR AS details
+FROM all_results
+ORDER BY status DESC, metric_value ASC, table_name, concept_field;

--- a/scripts/tests/test_data_freshness.sql
+++ b/scripts/tests/test_data_freshness.sql
@@ -1,0 +1,166 @@
+/*
+    Test: Data Freshness
+    
+    Checks that data is being received recently from GP practices.
+    Looks at MAX(date_recorded) per record_owner_organisation_code for each table.
+    Ignores future dates.
+    
+    Configuration:
+    - FRESHNESS_DAYS: Maximum days since last record (default: 5)
+    - PASS_THRESHOLD_PCT: Percentage of orgs that must be fresh (default: 90)
+    
+    Returns standardised test results with PASS/FAIL status.
+    
+    Tables with date_recorded:
+    - OBSERVATION
+    - DIAGNOSTIC_ORDER
+    - ENCOUNTER
+    - MEDICATION_ORDER
+    - MEDICATION_STATEMENT
+    - PROCEDURE_REQUEST
+    - ALLERGY_INTOLERANCE
+    - REFERRAL_REQUEST
+*/
+
+-- ============================================
+-- CONFIGURATION - Edit thresholds here
+-- ============================================
+SET freshness_days = 5;           -- Data should be within this many days
+SET pass_threshold_pct = 90.0;    -- This % of orgs should be fresh
+
+-- ============================================
+-- TEST EXECUTION
+-- ============================================
+WITH org_freshness AS (
+    -- OBSERVATION freshness by org
+    SELECT
+        'OBSERVATION' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- ENCOUNTER freshness by org
+    SELECT
+        'ENCOUNTER' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- MEDICATION_ORDER freshness by org
+    SELECT
+        'MEDICATION_ORDER' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- MEDICATION_STATEMENT freshness by org
+    SELECT
+        'MEDICATION_STATEMENT' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- DIAGNOSTIC_ORDER freshness by org
+    SELECT
+        'DIAGNOSTIC_ORDER' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.DIAGNOSTIC_ORDER
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- ALLERGY_INTOLERANCE freshness by org
+    SELECT
+        'ALLERGY_INTOLERANCE' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- PROCEDURE_REQUEST freshness by org
+    SELECT
+        'PROCEDURE_REQUEST' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PROCEDURE_REQUEST
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+    
+    UNION ALL
+    
+    -- REFERRAL_REQUEST freshness by org
+    SELECT
+        'REFERRAL_REQUEST' AS table_name,
+        record_owner_organisation_code AS org_code,
+        MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END) AS max_date_recorded,
+        DATEDIFF('day', MAX(CASE WHEN date_recorded <= CURRENT_DATE THEN date_recorded END), CURRENT_DATE) AS days_since_last
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.REFERRAL_REQUEST
+    WHERE record_owner_organisation_code IS NOT NULL
+    GROUP BY record_owner_organisation_code
+),
+
+table_summary AS (
+    SELECT
+        table_name,
+        COUNT(DISTINCT org_code) AS total_orgs,
+        COUNT(DISTINCT CASE WHEN days_since_last <= $freshness_days THEN org_code END) AS fresh_orgs,
+        COUNT(DISTINCT CASE WHEN days_since_last > $freshness_days THEN org_code END) AS stale_orgs,
+        ROUND(100.0 * COUNT(DISTINCT CASE WHEN days_since_last <= $freshness_days THEN org_code END) / NULLIF(COUNT(DISTINCT org_code), 0), 2) AS fresh_pct,
+        MIN(days_since_last) AS min_days_since,
+        MAX(days_since_last) AS max_days_since,
+        ROUND(AVG(days_since_last), 1) AS avg_days_since
+    FROM org_freshness
+    WHERE max_date_recorded IS NOT NULL
+    GROUP BY table_name
+)
+
+SELECT
+    'data_freshness' AS test_name,
+    table_name,
+    'date_recorded (by org)' AS test_subject,
+    CASE 
+        WHEN fresh_pct >= $pass_threshold_pct THEN 'PASS'
+        ELSE 'FAIL'
+    END AS status,
+    fresh_pct AS metric_value,
+    $pass_threshold_pct AS threshold,
+    OBJECT_CONSTRUCT(
+        'total_orgs', total_orgs,
+        'fresh_orgs', fresh_orgs,
+        'stale_orgs', stale_orgs,
+        'fresh_percentage', fresh_pct,
+        'freshness_days_threshold', $freshness_days,
+        'min_days_since_record', min_days_since,
+        'max_days_since_record', max_days_since,
+        'avg_days_since_record', avg_days_since
+    )::VARCHAR AS details
+FROM table_summary
+ORDER BY status DESC, fresh_pct ASC, table_name;

--- a/scripts/tests/test_referential_integrity.sql
+++ b/scripts/tests/test_referential_integrity.sql
@@ -1,0 +1,205 @@
+/*
+    Test: Referential Integrity
+    
+    Validates that foreign key columns reference existing records in parent tables.
+    Uses naming convention: <table_name>_id → <TABLE_NAME>.id
+    
+    Returns standardised test results with PASS/FAIL status.
+    Threshold: 100% referential integrity required
+*/
+
+WITH fk_checks AS (
+    -- OBSERVATION foreign keys
+    SELECT
+        'OBSERVATION' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT o.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN o.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN o.patient_id IS NOT NULL AND p.id IS NULL THEN o.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN o.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION o
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON o.patient_id = p.id
+    
+    UNION ALL
+    
+    SELECT
+        'OBSERVATION' AS child_table,
+        'encounter_id' AS fk_column,
+        'ENCOUNTER' AS parent_table,
+        COUNT(DISTINCT o.encounter_id) AS total_distinct_fk,
+        SUM(CASE WHEN o.encounter_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN o.encounter_id IS NOT NULL AND e.id IS NULL THEN o.encounter_id END) AS orphaned_fk,
+        SUM(CASE WHEN o.encounter_id IS NOT NULL AND e.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION o
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER e ON o.encounter_id = e.id
+    
+    UNION ALL
+    
+    SELECT
+        'OBSERVATION' AS child_table,
+        'practitioner_id' AS fk_column,
+        'PRACTITIONER' AS parent_table,
+        COUNT(DISTINCT o.practitioner_id) AS total_distinct_fk,
+        SUM(CASE WHEN o.practitioner_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN o.practitioner_id IS NOT NULL AND pr.id IS NULL THEN o.practitioner_id END) AS orphaned_fk,
+        SUM(CASE WHEN o.practitioner_id IS NOT NULL AND pr.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.OBSERVATION o
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PRACTITIONER pr ON o.practitioner_id = pr.id
+    
+    UNION ALL
+    
+    -- ENCOUNTER foreign keys
+    SELECT
+        'ENCOUNTER' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT e.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN e.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN e.patient_id IS NOT NULL AND p.id IS NULL THEN e.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN e.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER e
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON e.patient_id = p.id
+    
+    UNION ALL
+    
+    SELECT
+        'ENCOUNTER' AS child_table,
+        'practitioner_id' AS fk_column,
+        'PRACTITIONER' AS parent_table,
+        COUNT(DISTINCT e.practitioner_id) AS total_distinct_fk,
+        SUM(CASE WHEN e.practitioner_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN e.practitioner_id IS NOT NULL AND pr.id IS NULL THEN e.practitioner_id END) AS orphaned_fk,
+        SUM(CASE WHEN e.practitioner_id IS NOT NULL AND pr.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER e
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.PRACTITIONER pr ON e.practitioner_id = pr.id
+    
+    UNION ALL
+    
+    SELECT
+        'ENCOUNTER' AS child_table,
+        'episode_of_care_id' AS fk_column,
+        'EPISODE_OF_CARE' AS parent_table,
+        COUNT(DISTINCT e.episode_of_care_id) AS total_distinct_fk,
+        SUM(CASE WHEN e.episode_of_care_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN e.episode_of_care_id IS NOT NULL AND eoc.id IS NULL THEN e.episode_of_care_id END) AS orphaned_fk,
+        SUM(CASE WHEN e.episode_of_care_id IS NOT NULL AND eoc.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER e
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE eoc ON e.episode_of_care_id = eoc.id
+    
+    UNION ALL
+    
+    -- MEDICATION_ORDER foreign keys
+    SELECT
+        'MEDICATION_ORDER' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT mo.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN mo.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN mo.patient_id IS NOT NULL AND p.id IS NULL THEN mo.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN mo.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER mo
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON mo.patient_id = p.id
+    
+    UNION ALL
+    
+    SELECT
+        'MEDICATION_ORDER' AS child_table,
+        'medication_statement_id' AS fk_column,
+        'MEDICATION_STATEMENT' AS parent_table,
+        COUNT(DISTINCT mo.medication_statement_id) AS total_distinct_fk,
+        SUM(CASE WHEN mo.medication_statement_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN mo.medication_statement_id IS NOT NULL AND ms.id IS NULL THEN mo.medication_statement_id END) AS orphaned_fk,
+        SUM(CASE WHEN mo.medication_statement_id IS NOT NULL AND ms.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_ORDER mo
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT ms ON mo.medication_statement_id = ms.id
+    
+    UNION ALL
+    
+    -- MEDICATION_STATEMENT foreign keys
+    SELECT
+        'MEDICATION_STATEMENT' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT ms.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN ms.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN ms.patient_id IS NOT NULL AND p.id IS NULL THEN ms.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN ms.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.MEDICATION_STATEMENT ms
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON ms.patient_id = p.id
+    
+    UNION ALL
+    
+    -- EPISODE_OF_CARE foreign keys
+    SELECT
+        'EPISODE_OF_CARE' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT eoc.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN eoc.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN eoc.patient_id IS NOT NULL AND p.id IS NULL THEN eoc.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN eoc.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE eoc
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON eoc.patient_id = p.id
+    
+    UNION ALL
+    
+    SELECT
+        'EPISODE_OF_CARE' AS child_table,
+        'organisation_id' AS fk_column,
+        'ORGANISATION' AS parent_table,
+        COUNT(DISTINCT eoc.organisation_id) AS total_distinct_fk,
+        SUM(CASE WHEN eoc.organisation_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN eoc.organisation_id IS NOT NULL AND org.id IS NULL THEN eoc.organisation_id END) AS orphaned_fk,
+        SUM(CASE WHEN eoc.organisation_id IS NOT NULL AND org.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.EPISODE_OF_CARE eoc
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ORGANISATION org ON eoc.organisation_id = org.id
+    
+    UNION ALL
+    
+    -- ALLERGY_INTOLERANCE foreign keys
+    SELECT
+        'ALLERGY_INTOLERANCE' AS child_table,
+        'patient_id' AS fk_column,
+        'PATIENT' AS parent_table,
+        COUNT(DISTINCT ai.patient_id) AS total_distinct_fk,
+        SUM(CASE WHEN ai.patient_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN ai.patient_id IS NOT NULL AND p.id IS NULL THEN ai.patient_id END) AS orphaned_fk,
+        SUM(CASE WHEN ai.patient_id IS NOT NULL AND p.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE ai
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_MASKED.PATIENT p ON ai.patient_id = p.id
+    
+    UNION ALL
+    
+    SELECT
+        'ALLERGY_INTOLERANCE' AS child_table,
+        'encounter_id' AS fk_column,
+        'ENCOUNTER' AS parent_table,
+        COUNT(DISTINCT ai.encounter_id) AS total_distinct_fk,
+        SUM(CASE WHEN ai.encounter_id IS NOT NULL THEN 1 ELSE 0 END) AS total_rows_with_fk,
+        COUNT(DISTINCT CASE WHEN ai.encounter_id IS NOT NULL AND e.id IS NULL THEN ai.encounter_id END) AS orphaned_fk,
+        SUM(CASE WHEN ai.encounter_id IS NOT NULL AND e.id IS NULL THEN 1 ELSE 0 END) AS orphaned_rows
+    FROM "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ALLERGY_INTOLERANCE ai
+    LEFT JOIN "Data_Store_OLIDS_Alpha".OLIDS_COMMON.ENCOUNTER e ON ai.encounter_id = e.id
+)
+
+SELECT
+    'referential_integrity' AS test_name,
+    child_table AS table_name,
+    fk_column || ' → ' || parent_table AS test_subject,
+    CASE 
+        WHEN orphaned_fk = 0 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS status,
+    ROUND(100.0 * (total_distinct_fk - orphaned_fk) / NULLIF(total_distinct_fk, 0), 2) AS metric_value,
+    100.0 AS threshold,
+    OBJECT_CONSTRUCT(
+        'total_distinct_fk', total_distinct_fk,
+        'total_rows_with_fk', total_rows_with_fk,
+        'orphaned_fk_values', orphaned_fk,
+        'orphaned_rows', orphaned_rows,
+        'integrity_percentage', ROUND(100.0 * (total_distinct_fk - orphaned_fk) / NULLIF(total_distinct_fk, 0), 2)
+    )::VARCHAR AS details
+FROM fk_checks
+WHERE total_rows_with_fk > 0
+ORDER BY status DESC, metric_value ASC, child_table, fk_column;


### PR DESCRIPTION
## Summary
Adds standardised SQL test scripts for OLIDS data quality checks that colleagues can copy/paste and run directly.

## New Files
- test_concept_mapping.sql - Validates concept_id lookup chain
- test_column_completeness.sql - Checks NULL rates (configurable 1% threshold)
- test_referential_integrity.sql - Validates FK relationships
- test_data_freshness.sql - Checks date_recorded freshness by org (5 days, 90%)
- run_tests.py - Discovers and executes all test_*.sql files

## Standard Return Columns
All tests return: test_name, table_name, test_subject, status, metric_value, threshold, details

## Usage
Run individual SQL scripts in Snowflake, or use the Python runner:
- python run_tests.py (run all)
- python run_tests.py -t test_data_freshness.sql (run one)
- python run_tests.py -v (verbose)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated data quality testing framework for executing validation tests against Snowflake instances.
  * Introduced four new data quality tests: column completeness validation, concept mapping verification, data freshness checks, and referential integrity validation across multiple tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->