### PR TITLE
feat: enriched concept map with EMIS reference fallback

### DIFF
--- a/models/olids/base/base_emis_clinical_code.sql
+++ b/models/olids/base/base_emis_clinical_code.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        secure=true,
+        alias='emis_clinical_code')
+}}
+
+/*
+EMIS Clinical Code Reference
+EMIS-provided lookup mapping EMIS codes to SNOMED concepts.
+Used to enrich the concept map where mappings are missing or point to root concept.
+*/
+
+SELECT
+    emis_code_id,
+    olids_emis_code_concept_id,
+    term,
+    read_term_id,
+    snomed_ct_concept_id,
+    olids_snomed_concept_id,
+    snomed_ct_description_id,
+    national_code,
+    national_code_category,
+    national_description,
+    emis_code_category,
+    emis_parent_code_id,
+    lds_start_date_time
+FROM {{ source('emis_reference', 'PRIMARY_CARE_EMIS_CLINICAL_CODE') }}
+WHERE snomed_ct_concept_id IS NOT NULL

--- a/models/olids/base/base_emis_drug_code.sql
+++ b/models/olids/base/base_emis_drug_code.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        secure=true,
+        alias='emis_drug_code')
+}}
+
+/*
+EMIS Drug Code Reference
+EMIS-provided lookup mapping EMIS drug codes to dm+d product codes.
+*/
+
+SELECT
+    emis_drug_code_id,
+    olids_emis_drug_code_concept_id,
+    term,
+    dmd_product_code_id,
+    bnf_chapter_ref,
+    lds_start_date_time
+FROM {{ source('emis_reference', 'PRIMARY_CARE_EMIS_DRUG_CODE') }}

--- a/models/olids/base/base_olids_allergy_intolerance.sql
+++ b/models/olids/base/base_olids_allergy_intolerance.sql
@@ -60,9 +60,9 @@ INNER JOIN {{ ref('base_olids_patient') }} patients
     ON src.patient_id = patients.id
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} concept_map
     ON src.allergy_intolerance_source_concept_id = concept_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} date_precision_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} date_precision_map
     ON src.date_precision_concept_id = date_precision_map.source_code_id
 WHERE src.lds_start_date_time IS NOT NULL
 QUALIFY ROW_NUMBER() OVER (PARTITION BY src.id ORDER BY concept_map.target_display NULLS LAST, date_precision_map.target_display NULLS LAST) = 1

--- a/models/olids/base/base_olids_appointment.sql
+++ b/models/olids/base/base_olids_appointment.sql
@@ -70,11 +70,11 @@ INNER JOIN {{ ref('base_olids_patient') }} patients
     ON src.patient_id = patients.id
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} appointment_status_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} appointment_status_map
     ON src.appointment_status_concept_id = appointment_status_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} booking_method_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} booking_method_map
     ON src.booking_method_concept_id = booking_method_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} contact_mode_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} contact_mode_map
     ON src.contact_mode_concept_id = contact_mode_map.source_code_id
 WHERE src.patient_id IS NOT NULL
     AND src.start_date IS NOT NULL

--- a/models/olids/base/base_olids_episode_of_care.sql
+++ b/models/olids/base/base_olids_episode_of_care.sql
@@ -49,9 +49,9 @@ INNER JOIN {{ ref('base_olids_patient') }} patients
     ON src.patient_id = patients.id
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.organisation_code_publisher = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} episode_type_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} episode_type_map
     ON src.episode_type_source_concept_id = episode_type_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} episode_status_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} episode_status_map
     ON src.episode_status_source_concept_id = episode_status_map.source_code_id
 WHERE src.patient_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL

--- a/models/olids/base/base_olids_medication_order.sql
+++ b/models/olids/base/base_olids_medication_order.sql
@@ -74,9 +74,9 @@ INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
 LEFT JOIN {{ source('olids_common', 'MEDICATION_STATEMENT') }} ms
     ON src.medication_statement_id = ms.id
-LEFT JOIN {{ ref('base_olids_concept_map') }} concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} concept_map
     ON src.medication_order_source_concept_id = concept_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} date_precision_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} date_precision_map
     ON src.date_precision_concept_id = date_precision_map.source_code_id
 WHERE src.medication_order_source_concept_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL

--- a/models/olids/base/base_olids_medication_statement.sql
+++ b/models/olids/base/base_olids_medication_statement.sql
@@ -75,11 +75,11 @@ INNER JOIN {{ ref('base_olids_patient') }} patients
     ON src.patient_id = patients.id
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} concept_map
     ON src.medication_statement_source_concept_id = concept_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} auth_concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} auth_concept_map
     ON src.authorisation_type_concept_id = auth_concept_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} date_precision_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} date_precision_map
     ON src.date_precision_concept_id = date_precision_map.source_code_id
 WHERE src.medication_statement_source_concept_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL

--- a/models/olids/base/base_olids_observation.sql
+++ b/models/olids/base/base_olids_observation.sql
@@ -64,9 +64,9 @@ INNER JOIN {{ ref('base_olids_patient') }} patients
     ON src.patient_id = patients.id
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} concept_map
     ON src.observation_source_concept_id = concept_map.source_code_id
-LEFT JOIN {{ ref('base_olids_concept_map') }} unit_concept_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} unit_concept_map
     ON src.result_value_units_concept_id = unit_concept_map.source_code_id
 WHERE src.observation_source_concept_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL

--- a/models/olids/base/base_olids_patient.sql
+++ b/models/olids/base/base_olids_patient.sql
@@ -49,7 +49,7 @@ SELECT
 FROM {{ source('olids_masked', 'PATIENT') }} src
 INNER JOIN {{ ref('int_ncl_practices') }} ncl_practices
     ON src.record_owner_organisation_code = ncl_practices.practice_code
-LEFT JOIN {{ ref('base_olids_concept_map') }} gender_map
+LEFT JOIN {{ ref('int_enriched_concept_map') }} gender_map
     ON src.gender_concept_id = gender_map.source_code_id
 WHERE src.sk_patient_id IS NOT NULL
     AND src.is_spine_sensitive = FALSE

--- a/models/olids/intermediate/terminology/int_enriched_concept_map.sql
+++ b/models/olids/intermediate/terminology/int_enriched_concept_map.sql
@@ -1,0 +1,174 @@
+{{
+    config(
+        materialized='table',
+        schema='olids',
+        tags=['intermediate', 'terminology'],
+        cluster_by=['source_code_id', 'target_code_id'],
+        alias='enriched_concept_map')
+}}
+
+/*
+Enriched Concept Map
+Enhances the OLIDS concept map by:
+1. Replacing retired SNOMED target codes with their active successor (via SCT_History)
+2. Replacing root concept 138875005 targets with real SNOMED codes (via EMIS reference)
+3. Adding missing EMIS->SNOMED mappings not present in the concept map (via EMIS reference)
+*/
+
+WITH sct_history AS (
+    SELECT
+        h."OldConceptId" AS old_concept_id,
+        h."NewConceptId" AS new_concept_id,
+        h."NewConceptFullySpecifiedName" AS new_concept_display
+    FROM {{ source('nhsd_snomed', 'SCT_History') }} h
+    INNER JOIN {{ source('nhsd_snomed', 'SCT_Concept') }} sct
+        ON h."NewConceptId" = sct."Id"
+    WHERE h."IsAmbiguous" = FALSE
+        AND sct."Active" = TRUE
+),
+
+emis_clinical AS (
+    SELECT
+        olids_emis_code_concept_id,
+        emis_code_id,
+        term,
+        snomed_ct_concept_id,
+        olids_snomed_concept_id,
+        lds_start_date_time
+    FROM {{ ref('base_emis_clinical_code') }}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY olids_emis_code_concept_id
+        ORDER BY lds_start_date_time DESC
+    ) = 1
+),
+
+enriched_existing AS (
+    SELECT
+        cm.id,
+        cm.lds_id,
+        cm.lds_business_key,
+        cm.lds_dataset_id,
+        cm.concept_map_id,
+        cm.concept_map_resource_id,
+        cm.concept_map_url,
+        cm.concept_map_version,
+        cm.source_code_id,
+        cm.source_system,
+        cm.source_code,
+        cm.source_display,
+        CASE
+            WHEN cm.target_code = '138875005'
+                AND emis_ref.olids_snomed_concept_id IS NOT NULL
+                THEN emis_ref.olids_snomed_concept_id
+            ELSE cm.target_code_id
+        END AS target_code_id,
+        cm.target_system,
+        COALESCE(
+            CASE
+                WHEN cm.target_code = '138875005'
+                    AND emis_ref.snomed_ct_concept_id IS NOT NULL
+                    THEN emis_ref.snomed_ct_concept_id::VARCHAR
+            END,
+            sct_history.new_concept_id::VARCHAR,
+            cm.target_code
+        ) AS target_code,
+        COALESCE(
+            CASE
+                WHEN cm.target_code = '138875005'
+                    AND emis_ref.term IS NOT NULL
+                    THEN emis_ref.term
+            END,
+            sct_history.new_concept_display,
+            cm.target_display
+        ) AS target_display,
+        cm.is_primary,
+        cm.is_active,
+        cm.equivalence,
+        cm.lds_start_date_time
+    FROM {{ ref('base_olids_concept_map') }} cm
+    LEFT JOIN emis_clinical emis_ref
+        ON cm.source_code_id = emis_ref.olids_emis_code_concept_id
+        AND cm.target_code = '138875005'
+    LEFT JOIN {{ source('nhsd_snomed', 'SCT_Concept') }} sct
+        ON TRY_CAST(cm.target_code AS NUMBER(38,0)) = sct."Id"
+        AND sct."Active" = FALSE
+    LEFT JOIN sct_history
+        ON TRY_CAST(cm.target_code AS NUMBER(38,0)) = sct_history.old_concept_id
+        AND sct."Id" IS NOT NULL
+),
+
+missing_emis_mappings AS (
+    SELECT
+        'EMIS_BACKFILL_' || emis_ref.olids_emis_code_concept_id AS id,
+        NULL::VARCHAR AS lds_id,
+        NULL::VARCHAR AS lds_business_key,
+        NULL::VARCHAR AS lds_dataset_id,
+        NULL::VARCHAR AS concept_map_id,
+        NULL::VARCHAR AS concept_map_resource_id,
+        'http://LDS.nhs/EMIStoSNOMED/CodeID/cm' AS concept_map_url,
+        NULL::VARCHAR AS concept_map_version,
+        emis_ref.olids_emis_code_concept_id AS source_code_id,
+        'http://LDS.nhs/EMIS/CodeID/cs' AS source_system,
+        emis_ref.emis_code_id::VARCHAR AS source_code,
+        emis_ref.term AS source_display,
+        emis_ref.olids_snomed_concept_id AS target_code_id,
+        'http://snomed.info/sct' AS target_system,
+        emis_ref.snomed_ct_concept_id::VARCHAR AS target_code,
+        emis_ref.term AS target_display,
+        TRUE AS is_primary,
+        TRUE AS is_active,
+        'emis-reference-backfill' AS equivalence,
+        emis_ref.lds_start_date_time
+    FROM emis_clinical emis_ref
+    LEFT JOIN {{ ref('base_olids_concept_map') }} cm
+        ON emis_ref.olids_emis_code_concept_id = cm.source_code_id
+    WHERE cm.source_code_id IS NULL
+)
+
+SELECT
+    id,
+    lds_id,
+    lds_business_key,
+    lds_dataset_id,
+    concept_map_id,
+    concept_map_resource_id,
+    concept_map_url,
+    concept_map_version,
+    source_code_id,
+    source_system,
+    source_code,
+    source_display,
+    target_code_id,
+    target_system,
+    target_code,
+    target_display,
+    is_primary,
+    is_active,
+    equivalence,
+    lds_start_date_time
+FROM enriched_existing
+
+UNION ALL
+
+SELECT
+    id,
+    lds_id,
+    lds_business_key,
+    lds_dataset_id,
+    concept_map_id,
+    concept_map_resource_id,
+    concept_map_url,
+    concept_map_version,
+    source_code_id,
+    source_system,
+    source_code,
+    source_display,
+    target_code_id,
+    target_system,
+    target_code,
+    target_display,
+    is_primary,
+    is_active,
+    equivalence,
+    lds_start_date_time
+FROM missing_emis_mappings

--- a/models/olids/stable/stable_concept_map.sql
+++ b/models/olids/stable/stable_concept_map.sql
@@ -32,7 +32,7 @@ select
     is_active,
     equivalence,
     lds_start_date_time
-from {{ ref('base_olids_concept_map') }}
+from {{ ref('int_enriched_concept_map') }}
 
 {% if is_incremental() %}
     where lds_start_date_time > (select max(lds_start_date_time) from {{ this }})

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -1460,7 +1460,7 @@ sources:
     - name: HIGH_WATERMARK_DATE_TIME
       data_type: TIMESTAMP_NTZ
 - name: olids_terminology
-  database: '"Data_Store_OLIDS_Clinical_Validation"'
+  database: '"NCL_Data_Store_OLIDS_Alpha"'
   schema: '"OLIDS_TERMINOLOGY"'
   description: OLIDS-specific terminology and code mappings
   tables:
@@ -1530,6 +1530,47 @@ sources:
       data_type: TEXT
     - name: lds_start_date_time
       data_type: TIMESTAMP_NTZ
+- name: nhsd_snomed
+  database: '"Dictionary"'
+  schema: '"NHSD_SnomedReportingModel"'
+  description: NHS Digital SNOMED CT reporting model
+  tables:
+  - name: SCT_Concept
+    identifier: '"SCT_Concept"'
+    columns:
+    - name: Id
+      data_type: NUMBER
+    - name: EffectiveTime
+      data_type: TIMESTAMP_NTZ
+    - name: Active
+      data_type: BOOLEAN
+    - name: ModuleId
+      data_type: NUMBER
+    - name: DefinitionStatusId
+      data_type: NUMBER
+  - name: SCT_History
+    identifier: '"SCT_History"'
+    columns:
+    - name: OldConceptId
+      data_type: NUMBER
+    - name: OldConceptStatus
+      data_type: NUMBER
+    - name: NewConceptId
+      data_type: NUMBER
+    - name: NewConceptStatus
+      data_type: NUMBER
+    - name: Path
+      data_type: TEXT
+    - name: IsAmbiguous
+      data_type: BOOLEAN
+    - name: Iterations
+      data_type: NUMBER
+    - name: OldConceptFullySpecifiedName
+      data_type: TEXT
+    - name: NewConceptFullySpecifiedName
+      data_type: TEXT
+    - name: NewConceptFullySpecifiedNameStatus
+      data_type: NUMBER
 - name: dictionary
   database: '"Dictionary"'
   schema: '"dbo"'
@@ -1562,3 +1603,58 @@ sources:
       data_type: TEXT
     - name: STPName
       data_type: TEXT
+- name: emis_reference
+  database: '"Data_Store_OLIDS_Clinical_Validation"'
+  schema: '"REFERENCE"'
+  description: EMIS-provided reference tables for clinical and drug code lookups
+  tables:
+  - name: PRIMARY_CARE_EMIS_CLINICAL_CODE
+    identifier: '"PRIMARY_CARE_EMIS_CLINICAL_CODE"'
+    columns:
+    - name: EMIS_CODE_ID
+      data_type: NUMBER
+    - name: OLIDS_EMIS_CODE_CONCEPT_ID
+      data_type: TEXT
+    - name: OLIDS_EMIS_CODE_CONCEPT_BINARY_ID
+      data_type: BINARY
+    - name: TERM
+      data_type: TEXT
+    - name: READ_TERM_ID
+      data_type: TEXT
+    - name: SNOMED_CT_CONCEPT_ID
+      data_type: NUMBER
+    - name: OLIDS_SNOMED_CONCEPT_ID
+      data_type: TEXT
+    - name: OLIDS_SNOMED_CONCEPT_BINARY_ID
+      data_type: BINARY
+    - name: SNOMED_CT_DESCRIPTION_ID
+      data_type: NUMBER
+    - name: NATIONAL_CODE
+      data_type: TEXT
+    - name: NATIONAL_CODE_CATEGORY
+      data_type: TEXT
+    - name: NATIONAL_DESCRIPTION
+      data_type: TEXT
+    - name: EMIS_CODE_CATEGORY
+      data_type: TEXT
+    - name: EMIS_PARENT_CODE_ID
+      data_type: NUMBER
+    - name: LDS_START_DATE_TIME
+      data_type: TIMESTAMP_NTZ
+  - name: PRIMARY_CARE_EMIS_DRUG_CODE
+    identifier: '"PRIMARY_CARE_EMIS_DRUG_CODE"'
+    columns:
+    - name: EMIS_DRUG_CODE_ID
+      data_type: NUMBER
+    - name: OLIDS_EMIS_DRUG_CODE_CONCEPT_ID
+      data_type: TEXT
+    - name: OLIDS_EMIS_DRUG_CODE_CONCEPT_BINARY_ID
+      data_type: BINARY
+    - name: TERM
+      data_type: TEXT
+    - name: DMD_PRODUCT_CODE_ID
+      data_type: NUMBER
+    - name: BNF_CHAPTER_REF
+      data_type: TEXT
+    - name: LDS_START_DATE_TIME
+      data_type: TIMESTAMP_NTZ


### PR DESCRIPTION
## Summary

- Adds `int_enriched_concept_map` intermediate model that fixes three categories of concept map issues:
  - **Retired SNOMED targets** replaced with active successors (39,171 rows) via `Dictionary.NHSD_SnomedReportingModel.SCT_History` (non-ambiguous only)
  - **Root concept 138875005** targets swapped for real SNOMED codes (6,759 rows) using EMIS clinical code reference
  - **Missing EMIS→SNOMED mappings** backfilled (136,301 rows) from EMIS reference, tagged with `equivalence = 'emis-reference-backfill'`
- New base models for `PRIMARY_CARE_EMIS_CLINICAL_CODE` and `PRIMARY_CARE_EMIS_DRUG_CODE` sourced from `Data_Store_OLIDS_Clinical_Validation.REFERENCE`
- New `nhsd_snomed` source for `Dictionary.NHSD_SnomedReportingModel` (`SCT_Concept`, `SCT_History`)
- All base models updated to join `int_enriched_concept_map` instead of `base_olids_concept_map`
- `olids_terminology` source corrected to `NCL_Data_Store_OLIDS_Alpha`
- Enriched concept map materializes in `OLIDS` schema alongside stable tables

## Test plan

- [x] `dbt compile` passes
- [x] Full refresh running
- [x] Enriched concept map verified: 1,993,097 total rows (136,301 backfilled + 1,856,796 enriched existing)
- [x] Root concept rows reduced from 80,203 → 73,444
- [x] Retired concept replacements sampled and verified correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced clinical code reference data with enriched SNOMED concept mappings
  * Added automatic backfill capability for missing EMIS code mappings
  * Improved concept mapping resolution with historical SNOMED concept handling

* **Refactor**
  * Updated data sources to utilise enriched concept mapping datasets across relevant clinical models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->