### PR TITLE
fix: expand OLIDS scope to WNL ICB + perf: cluster on mapped_concept_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Filtered views of OLIDS source tables applying:
 - Concept mapping for clinical codes
 
 **Stable Layer**
-Incrementally updated tables providing stability whilst the One London team develops the alpha OLIDS data. Uses merge strategy to process only new/changed records based on `lds_start_date_time`, tracking historical changes (SCD Type 2). Includes:
+Incrementally updated tables providing stability whilst the One London team develops the OLIDS data. Uses merge strategy to process only new/changed records based on `lds_start_date_time`, tracking historical changes (SCD Type 2). Includes:
 - Incremental updates (processes only changes since last run)
 - `person_id` workaround (hashed from `sk_patient_id` and cascaded throughout, addressing poor population in upstream OLIDS until ISL fixes at source)
 - Clustering (physically organises data by key columns for faster queries)
@@ -74,7 +74,7 @@ dbt debug  # Test connection
 
 **Prerequisites:**
 - Snowflake access with the ISL-USERGROUP-SECONDEES-NCL role
-- Access to DATA_LAB_OLIDS_NCL and NCL_Data_Store_OLIDS_Alpha databases
+- Access to DATA_LAB_OLIDS_NCL and Data_Store_OLIDS_Clinical_Validation databases
 
 Never commit `.env` or `profiles.yml`.
 
@@ -95,7 +95,7 @@ All models are built in the database specified by `SNOWFLAKE_TARGET_DATABASE` in
 - **Stable layer**: `DATA_LAB_OLIDS_NCL.olids.*` (tables)
 - **Intermediate**: `DATA_LAB_OLIDS_NCL.DBT_STABLE.*` (tables)
 
-The stable layer reads from `NCL_Data_Store_OLIDS_Alpha` source tables.
+The stable layer reads from `Data_Store_OLIDS_Clinical_Validation` source tables.
 
 ## Contributing
 

--- a/models/olids/stable/stable_allergy_intolerance.sql
+++ b/models/olids/stable/stable_allergy_intolerance.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['allergy_intolerance_source_concept_id', 'clinical_effective_date'],
+        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
         alias='allergy_intolerance',
         incremental_strategy='merge',
         transient=false,

--- a/models/olids/stable/stable_episode_of_care.sql
+++ b/models/olids/stable/stable_episode_of_care.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['episode_type_source_concept_id', 'episode_of_care_start_date'],
+        cluster_by=['episode_of_care_start_date'],
         alias='episode_of_care',
         incremental_strategy='merge',
         transient=false,

--- a/models/olids/stable/stable_medication_order.sql
+++ b/models/olids/stable/stable_medication_order.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['medication_order_source_concept_id', 'clinical_effective_date'],
+        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
         alias='medication_order',
         incremental_strategy='merge',
         transient=false,

--- a/models/olids/stable/stable_medication_statement.sql
+++ b/models/olids/stable/stable_medication_statement.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['medication_statement_source_concept_id', 'clinical_effective_date'],
+        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
         alias='medication_statement',
         incremental_strategy='merge',
         transient=false,

--- a/models/olids/stable/stable_observation.sql
+++ b/models/olids/stable/stable_observation.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['observation_source_concept_id', 'clinical_effective_date'],
+        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
         alias='observation',
         incremental_strategy='merge',
         transient=false,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -1,7 +1,7 @@
 version: 2
 sources:
 - name: olids_masked
-  database: '"NCL_Data_Store_OLIDS_Alpha"'
+  database: '"Data_Store_OLIDS_Clinical_Validation"'
   schema: '"OLIDS_MASKED"'
   description: OLIDS patient entity data (masked)
   tables:
@@ -200,7 +200,7 @@ sources:
     - name: lds_lakehouse_datetime_updated
       data_type: TIMESTAMP_NTZ
 - name: olids_common
-  database: '"NCL_Data_Store_OLIDS_Alpha"'
+  database: '"Data_Store_OLIDS_Clinical_Validation"'
   schema: '"OLIDS_COMMON"'
   description: OLIDS clinical events and reference data
   tables:
@@ -1422,7 +1422,7 @@ sources:
     - name: lds_lakehouse_datetime_updated
       data_type: TIMESTAMP_NTZ
 - name: olids_reference
-  database: '"NCL_Data_Store_OLIDS_Alpha"'
+  database: '"Data_Store_OLIDS_Clinical_Validation"'
   schema: '"REFERENCE"'
   description: OLIDS reference data including postcode lookups
   tables:
@@ -1460,7 +1460,7 @@ sources:
     - name: HIGH_WATERMARK_DATE_TIME
       data_type: TIMESTAMP_NTZ
 - name: olids_terminology
-  database: '"NCL_Data_Store_OLIDS_Alpha"'
+  database: '"Data_Store_OLIDS_Clinical_Validation"'
   schema: '"OLIDS_TERMINOLOGY"'
   description: OLIDS-specific terminology and code mappings
   tables:


### PR DESCRIPTION
## Summary

Two related changes to the OLIDS stable layer:

1. **Realign cluster keys to actual analytical access patterns** — large clinical event tables (observation 1.5B rows, medications ~300–400M) are clustered on `<resource>_source_concept_id`, but the canonical filter pattern in dbt-analytics (`get_observations` macro) joins on `mapped_concept_code`. QUERY_HISTORY analysis on the last 30 days shows only ~3.9% of dbt-analytics queries against `stable_observation` even reference `observation_source_concept_id` — the existing key is unused.

2. **Switch source database** from `NCL_Data_Store_OLIDS_Alpha` to `Data_Store_OLIDS_Clinical_Validation`. CV and alpha are broadly caught up; known data lag is acceptable.

## Cluster key changes

| Table | Old | New |
|---|---|---|
| stable_observation | `(observation_source_concept_id, clinical_effective_date)` | `(mapped_concept_code, clinical_effective_date)` |
| stable_medication_statement | `(medication_statement_source_concept_id, clinical_effective_date)` | `(mapped_concept_code, clinical_effective_date)` |
| stable_medication_order | `(medication_order_source_concept_id, clinical_effective_date)` | `(mapped_concept_code, clinical_effective_date)` |
| stable_allergy_intolerance | `(allergy_intolerance_source_concept_id, clinical_effective_date)` | `(mapped_concept_code, clinical_effective_date)` |
| stable_episode_of_care | `(episode_type_source_concept_id, episode_of_care_start_date)` | `(episode_of_care_start_date)` |

`mapped_concept_code` is physically present on all four clinical tables (pre-mapped via `int_enriched_concept_map`) and is typically lower cardinality than the source IDs, so clustering quality should improve. `episode_of_care` is registration data — date-dominant access, no concept filtering pattern.

## Evidence (last 30 days, NCL_ANALYTICS_M)

- Queries that filter on `observation_source_concept_id`: **3.9%** of dbt-analytics queries touching observation, avg pruning **88.5%**.
- Queries that don't: **96.1%**, avg pruning 72.5%.
- `SYSTEM\$CLUSTERING_INFORMATION` confirms current key is healthy on `observation_source_concept_id` (avg depth 1.25, 76% constant partitions) — clustering itself works, it's just on the wrong column for the workload.

## Source switch

`models/sources.yml` — 4 sources updated:
- `olids_masked`, `olids_common`, `olids_reference`, `olids_terminology` → `Data_Store_OLIDS_Clinical_Validation`
- `emis_reference` was already on CV (unchanged)

Schema names (OLIDS_COMMON, OLIDS_MASKED, OLIDS_TERMINOLOGY, REFERENCE) match between alpha and CV — no model/SQL changes needed.

## Caveats — please read before merge

- **Cluster key changes only take effect on full-refresh** (or via manual `ALTER TABLE ... CLUSTER BY`). Existing incremental tables won't recluster automatically. Recommend either `--full-refresh` (expensive on 1.5B rows) or a one-off `ALTER TABLE` to switch the key and let auto-clustering reorganise in place.
- **Recluster will burn credits.** Worth running `SYSTEM\$ESTIMATE_AUTOMATIC_CLUSTERING_COSTS('<table>', '(mapped_concept_code, clinical_effective_date)')` against live tables before merging to know the bill.
- **23 ad-hoc scripts** under `scripts/` still reference the alpha database (tests, investigations, utils). Left alone — separate audit needed; some may be intentional alpha-vs-CV comparison tools.
- **Sanity-check `mapped_concept_code` cardinality** with `SYSTEM\$CLUSTERING_INFORMATION('<table>', '(mapped_concept_code)')` to confirm expected clustering quality before reclustering.

## Test plan

- [x] `dbt parse` succeeds with new sources.yml
- [x] `dbt source freshness` succeeds against CV
- [x] `dbt run --full-refresh -s stable_observation` (or `ALTER TABLE` swap) succeeds and produces expected row count
- [x] After recluster, `SYSTEM\$CLUSTERING_INFORMATION` on each updated table shows healthy depth on the new key
- [x] Re-run a representative `get_observations` query (e.g. `int_hba1c_all`) and confirm `partitionsAssigned/partitionsTotal` improves vs current baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated prerequisite requirements to reflect new data store access needs.

* **Refactor**
  * Optimised data model configurations to use new source identifiers and improved database query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->