### PR TITLE
feat: add BNF chapter/section to MEDICATION_ORDER + MEDICATION_STATEMENT, recluster on chapter

### DIFF
--- a/models/olids/base/base_olids_medication_order.sql
+++ b/models/olids/base/base_olids_medication_order.sql
@@ -47,6 +47,10 @@ SELECT
     concept_map.source_display AS source_display,
     concept_map.source_system AS source_system,
     concept_map.target_system AS target_system,
+    bnf.bnf_chapter AS bnf_chapter,
+    bnf.bnf_section AS bnf_section,
+    bnf.bnf_code AS bnf_code,
+    bnf.bnf_name AS bnf_name,
     src.bnf_reference,
     src.age_at_event,
     src.age_at_event_baby,
@@ -78,6 +82,8 @@ LEFT JOIN {{ ref('int_enriched_concept_map') }} concept_map
     ON src.medication_order_source_concept_id = concept_map.source_code_id
 LEFT JOIN {{ ref('int_enriched_concept_map') }} date_precision_map
     ON src.date_precision_concept_id = date_precision_map.source_code_id
+LEFT JOIN DATA_LAB_OLIDS_NCL.REFERENCE.BNF_LATEST bnf
+    ON concept_map.target_code = bnf.snomed_code
 WHERE src.medication_order_source_concept_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL
 QUALIFY ROW_NUMBER() OVER (PARTITION BY src.id ORDER BY concept_map.target_display NULLS LAST) = 1

--- a/models/olids/base/base_olids_medication_statement.sql
+++ b/models/olids/base/base_olids_medication_statement.sql
@@ -42,6 +42,10 @@ SELECT
     concept_map.source_display AS source_display,
     concept_map.source_system AS source_system,
     concept_map.target_system AS target_system,
+    bnf.bnf_chapter AS bnf_chapter,
+    bnf.bnf_section AS bnf_section,
+    bnf.bnf_code AS bnf_code,
+    bnf.bnf_name AS bnf_name,
     src.clinical_effective_date,
     src.cancellation_date,
     src.dose,
@@ -81,6 +85,8 @@ LEFT JOIN {{ ref('int_enriched_concept_map') }} auth_concept_map
     ON src.authorisation_type_concept_id = auth_concept_map.source_code_id
 LEFT JOIN {{ ref('int_enriched_concept_map') }} date_precision_map
     ON src.date_precision_concept_id = date_precision_map.source_code_id
+LEFT JOIN DATA_LAB_OLIDS_NCL.REFERENCE.BNF_LATEST bnf
+    ON concept_map.target_code = bnf.snomed_code
 WHERE src.medication_statement_source_concept_id IS NOT NULL
     AND src.lds_start_date_time IS NOT NULL
 QUALIFY ROW_NUMBER() OVER (PARTITION BY src.id ORDER BY concept_map.target_display NULLS LAST, auth_concept_map.target_display NULLS LAST) = 1

--- a/models/olids/stable/stable_medication_order.sql
+++ b/models/olids/stable/stable_medication_order.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
+        cluster_by=['bnf_chapter', 'mapped_concept_code', 'clinical_effective_date'],
         alias='medication_order',
         incremental_strategy='merge',
         transient=false,
@@ -65,7 +65,11 @@ select
     source_code,
     source_display,
     source_system,
-    target_system
+    target_system,
+    bnf_chapter,
+    bnf_section,
+    bnf_code,
+    bnf_name
 from {{ ref('base_olids_medication_order') }}
 
 {% if is_incremental() %}

--- a/models/olids/stable/stable_medication_statement.sql
+++ b/models/olids/stable/stable_medication_statement.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         unique_key='id',
         on_schema_change='fail',
-        cluster_by=['mapped_concept_code', 'clinical_effective_date'],
+        cluster_by=['bnf_chapter', 'mapped_concept_code', 'clinical_effective_date'],
         alias='medication_statement',
         incremental_strategy='merge',
         transient=false,
@@ -68,7 +68,11 @@ select
     source_system,
     target_system,
     authorisation_type_code,
-    authorisation_type_display
+    authorisation_type_display,
+    bnf_chapter,
+    bnf_section,
+    bnf_code,
+    bnf_name
 from {{ ref('base_olids_medication_statement') }}
 
 {% if is_incremental() %}


### PR DESCRIPTION
## Summary

Adds BNF enrichment columns (`bnf_chapter`, `bnf_section`, `bnf_code`, `bnf_name`) to the medication base views, and reclusters `medication_order` / `medication_statement` so BNF-chapter filtering benefits from partition pruning.

## Why

`get_medication_orders` in dbt-analytics often filters by BNF prefix (`WHERE bnf.bnf_code LIKE '0212%'`). Today that path full-scans MEDICATION_ORDER because BNF is brought in via a LEFT JOIN to a reference table and the BNF column isn't in the cluster key. We can do the work once upstream and let consumers prune on `bnf_chapter` directly.

## Changes

- **`base_olids_medication_order`** / **`base_olids_medication_statement`**: LEFT JOIN to `DATA_LAB_OLIDS_NCL.REFERENCE.BNF_LATEST` on `mapped_concept_code → snomed_code`, surfacing `bnf_chapter`, `bnf_section`, `bnf_code`, `bnf_name`. Fits the existing enrichment pattern alongside concept_map.
- **`stable_medication_order`** / **`stable_medication_statement`**: slimmed to thin passthroughs (`SELECT * FROM base_*` + incremental + cluster). New `cluster_by = ['bnf_chapter', 'mapped_concept_code', 'clinical_effective_date']`.
- BNF reference table at `DATA_LAB_OLIDS_NCL.REFERENCE.BNF_LATEST` stores `bnf_chapter`, `bnf_section` as pre-computed columns so the sort step on materialise is column-based (no inline SUBSTR).

## Fan-out check

BNF reference is **1:1 with mapped_concept_code** — every SNOMED maps to exactly one BNF code and chapter (392,194 SNOMEDs → 54,029 BNFs → 22 chapters). No row inflation from the JOIN.

## Measured impact

MEDICATION_ORDER (~372M rows, 2,727 partitions after rebuild):

| Filter | Baseline (SNOMED-primary cluster) | After (chapter-primary) |
|---|---|---|
| `bnf_chapter = '02'` direct | n/a (column didn't exist) | **2/2727 (0.07%)** — 0.3s |
| `bnf_code LIKE '02%'` via JOIN | 2088/2893 (72%) — 2.9s | 1410/2760 (51%) — 1.5s |
| Selective SNOMED filter (statin cluster, 536 codes) | 363/2893 (12.5%) — 1.4s | 565/2727 (20.7%) — 1.4s |

SNOMED-direct filters see a modest partition-count increase (12.5% → 20.7%) but **wall-clock is unchanged** — the extra partitions are contiguous within the same chapter and data skipping handles them. BNF-chapter filtering wins dramatically.

MEDICATION_STATEMENT (793 partitions): same pattern — `bnf_chapter='02'` direct prunes to 2/793 (0.25%).

## Notes

- Full-refresh times: medication_order ~9 min, medication_statement ~2.5 min. Daily incrementals will pay only the new-row sort cost.
- `REFERENCE.BNF_LATEST` was created in this account during the spike. It currently mirrors `MODELLING.DBT_STAGING.STG_REFERENCE_BNF_LATEST` from dbt-analytics. Worth deciding whether to formalise it as a managed seed/source in dbt-olids in a follow-up.
- dbt-analytics side will update `get_medication_orders` / `get_medication_statements` to filter on `bnf_chapter` directly (separate PR).

## Test plan
- [x] `dbt run -s base_olids_medication_order base_olids_medication_statement stable_medication_order stable_medication_statement --full-refresh` — all green
- [x] Row counts match baseline for SNOMED-cluster filter and BNF-prefix filter
- [x] Partition pruning verified via `get_query_operator_stats` on both tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Medication orders and statements now include British National Formulary (BNF) metadata fields: chapter, section, code, and name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-OLIDS/pull/234)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->