### PR TITLE
feat: person identity resolution with cross-feed collapsing

### DIFF
--- a/models/indexes/person_id_index.sql
+++ b/models/indexes/person_id_index.sql
@@ -10,6 +10,10 @@
     )
 }}
 
+-- Mint only for persons seen on patient rows. Person-table-only ids carry no
+-- sk/DOB attributes, so minting them early would permanently split them from
+-- their cross-feed twins once their practice's data lands (append-only ids
+-- never re-resolve). Persons without a registration never surface downstream.
 WITH source_ids AS (
     SELECT DISTINCT
         person_id::VARCHAR AS source_person_id,
@@ -21,29 +25,11 @@ WITH source_ids AS (
     UNION DISTINCT
 
     SELECT DISTINCT
-        id::VARCHAR AS source_person_id,
-        'OLIDS'::VARCHAR AS source_feed,
-        1::NUMBER(38, 0) AS feed_order
-    FROM {{ ref('landing_person') }}
-    WHERE id IS NOT NULL
-
-    UNION DISTINCT
-
-    SELECT DISTINCT
         person_id::VARCHAR AS source_person_id,
         'SYNAPSE'::VARCHAR AS source_feed,
         2::NUMBER(38, 0) AS feed_order
     FROM {{ source('olids_masked', 'PATIENT') }}
     WHERE person_id IS NOT NULL
-
-    UNION DISTINCT
-
-    SELECT DISTINCT
-        id::VARCHAR AS source_person_id,
-        'SYNAPSE'::VARCHAR AS source_feed,
-        2::NUMBER(38, 0) AS feed_order
-    FROM {{ source('olids_masked', 'PERSON') }}
-    WHERE id IS NOT NULL
 ),
 
 patient_rows AS (

--- a/models/indexes/person_id_index.sql
+++ b/models/indexes/person_id_index.sql
@@ -13,8 +13,8 @@
 WITH source_ids AS (
     SELECT DISTINCT
         person_id::VARCHAR AS source_person_id,
-        'OLIDS' AS source_feed,
-        1 AS feed_order
+        'OLIDS'::VARCHAR AS source_feed,
+        1::NUMBER(38, 0) AS feed_order
     FROM {{ ref('landing_patient') }}
     WHERE person_id IS NOT NULL
 
@@ -22,8 +22,8 @@ WITH source_ids AS (
 
     SELECT DISTINCT
         id::VARCHAR AS source_person_id,
-        'OLIDS' AS source_feed,
-        1 AS feed_order
+        'OLIDS'::VARCHAR AS source_feed,
+        1::NUMBER(38, 0) AS feed_order
     FROM {{ ref('landing_person') }}
     WHERE id IS NOT NULL
 
@@ -31,8 +31,8 @@ WITH source_ids AS (
 
     SELECT DISTINCT
         person_id::VARCHAR AS source_person_id,
-        'SYNAPSE' AS source_feed,
-        2 AS feed_order
+        'SYNAPSE'::VARCHAR AS source_feed,
+        2::NUMBER(38, 0) AS feed_order
     FROM {{ source('olids_masked', 'PATIENT') }}
     WHERE person_id IS NOT NULL
 
@@ -40,57 +40,462 @@ WITH source_ids AS (
 
     SELECT DISTINCT
         id::VARCHAR AS source_person_id,
-        'SYNAPSE' AS source_feed,
-        2 AS feed_order
+        'SYNAPSE'::VARCHAR AS source_feed,
+        2::NUMBER(38, 0) AS feed_order
     FROM {{ source('olids_masked', 'PERSON') }}
     WHERE id IS NOT NULL
 ),
 
-deduplicated AS (
+patient_rows AS (
     SELECT
-        source_person_id,
-        source_feed
+        person_id::VARCHAR AS source_person_id,
+        TRY_TO_NUMBER(sk_patient_id)::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month
+    FROM {{ ref('landing_patient') }}
+    -- deleted registrations excluded: stale attributes must not poison resolution
+    WHERE person_id IS NOT NULL
+        AND COALESCE(lds_is_deleted, FALSE) = FALSE
+
+    UNION ALL
+
+    SELECT
+        person_id::VARCHAR AS source_person_id,
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month
+    FROM {{ source('olids_masked', 'PATIENT') }}
+    WHERE person_id IS NOT NULL
+        AND COALESCE(lds_is_deleted, FALSE) = FALSE
+),
+
+deduplicated_sources AS (
+    SELECT
+        source_person_id::VARCHAR AS source_person_id,
+        source_feed::VARCHAR AS source_feed
     FROM source_ids
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY source_person_id
-        ORDER BY feed_order
+        ORDER BY feed_order, source_feed
     ) = 1
 ),
 
-new_ids AS (
+patient_attributes AS (
     SELECT
-        source_person_id,
-        source_feed
-    FROM deduplicated
+        source_person_id::VARCHAR AS source_person_id,
+        COUNT(DISTINCT sk_patient_id)::NUMBER(38, 0) AS sk_count,
+        COUNT(DISTINCT
+            CASE
+                WHEN birth_year IS NOT NULL AND birth_month IS NOT NULL
+                    THEN birth_year::VARCHAR || '-' || birth_month::VARCHAR
+            END
+        )::NUMBER(38, 0) AS dob_count,
+        MIN(sk_patient_id)::NUMBER(38, 0) AS resolved_sk_patient_id,
+        MIN(birth_year)::NUMBER(38, 0) AS resolved_birth_year,
+        MIN(birth_month)::NUMBER(38, 0) AS resolved_birth_month
+    FROM patient_rows
+    GROUP BY source_person_id
+),
+
+source_attributes AS (
+    SELECT
+        src.source_person_id::VARCHAR AS source_person_id,
+        src.source_feed::VARCHAR AS source_feed,
+        COALESCE(attr.sk_count, 0)::NUMBER(38, 0) AS sk_count,
+        COALESCE(attr.dob_count, 0)::NUMBER(38, 0) AS dob_count,
+        CASE
+            WHEN COALESCE(attr.sk_count, 0) = 1
+                THEN attr.resolved_sk_patient_id
+        END::NUMBER(38, 0) AS sk_patient_id,
+        CASE
+            WHEN COALESCE(attr.dob_count, 0) = 1
+                THEN attr.resolved_birth_year
+        END::NUMBER(38, 0) AS birth_year,
+        CASE
+            WHEN COALESCE(attr.dob_count, 0) = 1
+                THEN attr.resolved_birth_month
+        END::NUMBER(38, 0) AS birth_month,
+        (
+            COALESCE(attr.sk_count, 0) = 1
+            AND COALESCE(attr.dob_count, 0) = 1
+        )::BOOLEAN AS is_resolvable
+    FROM deduplicated_sources AS src
+    LEFT JOIN patient_attributes AS attr
+        ON src.source_person_id = attr.source_person_id
+),
+
+resolvable_keys AS (
+    SELECT
+        source_person_id::VARCHAR AS source_person_id,
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month
+    FROM source_attributes
+    WHERE is_resolvable
+),
+
+key_stats AS (
+    SELECT
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month,
+        COUNT(*)::NUMBER(38, 0) AS cluster_size
+    FROM resolvable_keys
+    GROUP BY sk_patient_id, birth_year, birth_month
+),
+
+sk_stats AS (
+    SELECT
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        COUNT(DISTINCT source_person_id)::NUMBER(38, 0) AS sk_source_count
+    FROM resolvable_keys
+    GROUP BY sk_patient_id
+),
+
+classified_sources AS (
+    SELECT
+        src.source_person_id::VARCHAR AS source_person_id,
+        src.source_feed::VARCHAR AS source_feed,
+        src.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        src.birth_year::NUMBER(38, 0) AS birth_year,
+        src.birth_month::NUMBER(38, 0) AS birth_month,
+        src.sk_count::NUMBER(38, 0) AS sk_count,
+        src.dob_count::NUMBER(38, 0) AS dob_count,
+        src.is_resolvable::BOOLEAN AS is_resolvable,
+        COALESCE(key_stats.cluster_size, 0)::NUMBER(38, 0) AS cluster_size,
+        COALESCE(sk_stats.sk_source_count, 0)::NUMBER(38, 0) AS sk_source_count,
+        (
+            src.is_resolvable
+            AND COALESCE(key_stats.cluster_size, 0) > 1
+        )::BOOLEAN AS cluster_eligible,
+        CASE
+            WHEN src.sk_count > 1 THEN 'multi_sk'
+            WHEN src.dob_count > 1 THEN 'ambiguous_dob'
+            WHEN src.is_resolvable
+                AND COALESCE(key_stats.cluster_size, 0) = 1
+                AND COALESCE(sk_stats.sk_source_count, 0) > 1
+                THEN 'sk_dob_mismatch'
+        END::VARCHAR AS review_reason
+    FROM source_attributes AS src
+    LEFT JOIN key_stats
+        ON src.sk_patient_id = key_stats.sk_patient_id
+        AND src.birth_year = key_stats.birth_year
+        AND src.birth_month = key_stats.birth_month
+    LEFT JOIN sk_stats
+        ON src.sk_patient_id = sk_stats.sk_patient_id
+),
+
+new_sources AS (
+    SELECT
+        classified_sources.source_person_id::VARCHAR AS source_person_id,
+        classified_sources.source_feed::VARCHAR AS source_feed,
+        classified_sources.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        classified_sources.birth_year::NUMBER(38, 0) AS birth_year,
+        classified_sources.birth_month::NUMBER(38, 0) AS birth_month,
+        classified_sources.sk_count::NUMBER(38, 0) AS sk_count,
+        classified_sources.dob_count::NUMBER(38, 0) AS dob_count,
+        classified_sources.is_resolvable::BOOLEAN AS is_resolvable,
+        classified_sources.cluster_eligible::BOOLEAN AS cluster_eligible,
+        classified_sources.review_reason::VARCHAR AS review_reason
+    FROM classified_sources
     {% if is_incremental() %}
-        WHERE source_person_id NOT IN (
-            SELECT source_person_id
-            FROM {{ this }}
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM {{ this }} AS existing
+            WHERE existing.source_person_id = classified_sources.source_person_id
         )
     {% endif %}
 ),
 
-assigned AS (
+{% if is_incremental() %}
+
+existing_candidates AS (
     SELECT
-        source_person_id,
-        {% if is_incremental() %}
-            (
-                COALESCE((SELECT MAX(person_seq) FROM {{ this }}), 0)
-                + ROW_NUMBER() OVER (ORDER BY source_person_id)
-            )::NUMBER(38, 0
-            ) AS person_seq,
-        {% else %}
-        ROW_NUMBER() OVER (ORDER BY source_person_id)::NUMBER(38, 0) AS person_seq,
-        {% endif %}
-        source_feed,
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month,
+        COUNT(DISTINCT person_id)::NUMBER(38, 0) AS candidate_count,
+        MIN(person_id)::NUMBER(38, 0) AS candidate_person_id,
+        MIN(person_seq)::NUMBER(38, 0) AS candidate_person_seq
+    FROM {{ this }}
+    WHERE sk_patient_id IS NOT NULL
+        AND birth_year IS NOT NULL
+        AND birth_month IS NOT NULL
+    GROUP BY sk_patient_id, birth_year, birth_month
+),
+
+existing_sk_stats AS (
+    SELECT
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        COUNT(DISTINCT person_id)::NUMBER(38, 0) AS existing_sk_person_count
+    FROM {{ this }}
+    WHERE sk_patient_id IS NOT NULL
+    GROUP BY sk_patient_id
+),
+
+new_with_candidates AS (
+    SELECT
+        src.source_person_id::VARCHAR AS source_person_id,
+        src.source_feed::VARCHAR AS source_feed,
+        src.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        src.birth_year::NUMBER(38, 0) AS birth_year,
+        src.birth_month::NUMBER(38, 0) AS birth_month,
+        src.sk_count::NUMBER(38, 0) AS sk_count,
+        src.dob_count::NUMBER(38, 0) AS dob_count,
+        src.is_resolvable::BOOLEAN AS is_resolvable,
+        COALESCE(candidates.candidate_count, 0)::NUMBER(38, 0) AS candidate_count,
+        candidates.candidate_person_id::NUMBER(38, 0) AS candidate_person_id,
+        candidates.candidate_person_seq::NUMBER(38, 0) AS candidate_person_seq,
+        COALESCE(existing_sk_stats.existing_sk_person_count, 0)::NUMBER(38, 0) AS existing_sk_person_count,
+        src.review_reason::VARCHAR AS source_review_reason
+    FROM new_sources AS src
+    LEFT JOIN existing_candidates AS candidates
+        ON src.sk_patient_id = candidates.sk_patient_id
+        AND src.birth_year = candidates.birth_year
+        AND src.birth_month = candidates.birth_month
+    LEFT JOIN existing_sk_stats
+        ON src.sk_patient_id = existing_sk_stats.sk_patient_id
+),
+
+alias_rows AS (
+    SELECT
+        source_person_id::VARCHAR AS source_person_id,
+        candidate_person_id::NUMBER(38, 0) AS person_id,
+        candidate_person_seq::NUMBER(38, 0) AS person_seq,
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month,
+        source_feed::VARCHAR AS source_feed,
+        'sk_dob_alias'::VARCHAR AS match_method,
+        NULL::VARCHAR AS review_reason,
         CURRENT_TIMESTAMP()::TIMESTAMP_NTZ AS first_seen_at
-    FROM new_ids
+    FROM new_with_candidates
+    WHERE is_resolvable
+        AND candidate_count = 1
+),
+
+to_mint AS (
+    SELECT
+        source_person_id::VARCHAR AS source_person_id,
+        source_feed::VARCHAR AS source_feed,
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month,
+        sk_count::NUMBER(38, 0) AS sk_count,
+        dob_count::NUMBER(38, 0) AS dob_count,
+        is_resolvable::BOOLEAN AS is_resolvable,
+        candidate_count::NUMBER(38, 0) AS candidate_count,
+        existing_sk_person_count::NUMBER(38, 0) AS existing_sk_person_count,
+        source_review_reason::VARCHAR AS source_review_reason
+    FROM new_with_candidates
+    WHERE NOT (
+        is_resolvable
+        AND candidate_count = 1
+    )
+),
+
+new_key_stats AS (
+    SELECT
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        birth_year::NUMBER(38, 0) AS birth_year,
+        birth_month::NUMBER(38, 0) AS birth_month,
+        COUNT(*)::NUMBER(38, 0) AS new_cluster_size
+    FROM to_mint
+    WHERE is_resolvable
+    GROUP BY sk_patient_id, birth_year, birth_month
+),
+
+new_sk_stats AS (
+    SELECT
+        sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        COUNT(DISTINCT source_person_id)::NUMBER(38, 0) AS new_sk_source_count
+    FROM to_mint
+    WHERE is_resolvable
+    GROUP BY sk_patient_id
+),
+
+mint_classified AS (
+    SELECT
+        mint.source_person_id::VARCHAR AS source_person_id,
+        mint.source_feed::VARCHAR AS source_feed,
+        mint.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        mint.birth_year::NUMBER(38, 0) AS birth_year,
+        mint.birth_month::NUMBER(38, 0) AS birth_month,
+        mint.is_resolvable::BOOLEAN AS is_resolvable,
+        COALESCE(new_key_stats.new_cluster_size, 0)::NUMBER(38, 0) AS new_cluster_size,
+        CASE
+            WHEN mint.candidate_count > 1 THEN 'ambiguous_candidates'
+            WHEN mint.sk_count > 1 THEN 'multi_sk'
+            WHEN mint.dob_count > 1 THEN 'ambiguous_dob'
+            WHEN mint.is_resolvable
+                AND COALESCE(new_key_stats.new_cluster_size, 0) = 1
+                AND (
+                    COALESCE(new_sk_stats.new_sk_source_count, 0) > 1
+                    OR mint.existing_sk_person_count > 0
+                )
+                THEN 'sk_dob_mismatch'
+        END::VARCHAR AS review_reason,
+        (
+            mint.is_resolvable
+            AND COALESCE(new_key_stats.new_cluster_size, 0) > 1
+        )::BOOLEAN AS new_cluster_eligible
+    FROM to_mint AS mint
+    LEFT JOIN new_key_stats
+        ON mint.sk_patient_id = new_key_stats.sk_patient_id
+        AND mint.birth_year = new_key_stats.birth_year
+        AND mint.birth_month = new_key_stats.birth_month
+    LEFT JOIN new_sk_stats
+        ON mint.sk_patient_id = new_sk_stats.sk_patient_id
+),
+
+assignment_units AS (
+    SELECT
+        CASE
+            WHEN new_cluster_eligible
+                THEN (
+                    'SKDOB:' || sk_patient_id::VARCHAR
+                    || ':' || birth_year::VARCHAR
+                    || ':' || birth_month::VARCHAR
+                )
+            ELSE 'SRC:' || source_person_id
+        END::VARCHAR AS assignment_key,
+        MIN(source_person_id)::VARCHAR AS unit_order_key
+    FROM mint_classified
+    GROUP BY assignment_key
+),
+
+numbered_units AS (
+    SELECT
+        assignment_key::VARCHAR AS assignment_key,
+        (
+            COALESCE((SELECT MAX(person_seq) FROM {{ this }}), 0)
+            + DENSE_RANK() OVER (ORDER BY unit_order_key, assignment_key)
+        )::NUMBER(38, 0) AS person_seq
+    FROM assignment_units
+),
+
+minted_rows AS (
+    SELECT
+        mint.source_person_id::VARCHAR AS source_person_id,
+        (100000000 + numbered_units.person_seq)::NUMBER(38, 0) AS person_id,
+        numbered_units.person_seq::NUMBER(38, 0) AS person_seq,
+        mint.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        mint.birth_year::NUMBER(38, 0) AS birth_year,
+        mint.birth_month::NUMBER(38, 0) AS birth_month,
+        mint.source_feed::VARCHAR AS source_feed,
+        CASE
+            WHEN mint.new_cluster_eligible THEN 'sk_dob_cluster'
+            ELSE 'minted'
+        END::VARCHAR AS match_method,
+        mint.review_reason::VARCHAR AS review_reason,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ AS first_seen_at
+    FROM mint_classified AS mint
+    INNER JOIN numbered_units
+        ON CASE
+            WHEN mint.new_cluster_eligible
+                THEN (
+                    'SKDOB:' || mint.sk_patient_id::VARCHAR
+                    || ':' || mint.birth_year::VARCHAR
+                    || ':' || mint.birth_month::VARCHAR
+                )
+            ELSE 'SRC:' || mint.source_person_id
+        END = numbered_units.assignment_key
 )
 
 SELECT
-    source_person_id,
-    person_seq,
-    source_feed,
-    first_seen_at,
-    100000000 + person_seq AS person_id
-FROM assigned
+    source_person_id::VARCHAR AS source_person_id,
+    person_id::NUMBER(38, 0) AS person_id,
+    person_seq::NUMBER(38, 0) AS person_seq,
+    sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+    birth_year::NUMBER(38, 0) AS birth_year,
+    birth_month::NUMBER(38, 0) AS birth_month,
+    source_feed::VARCHAR AS source_feed,
+    match_method::VARCHAR AS match_method,
+    review_reason::VARCHAR AS review_reason,
+    first_seen_at::TIMESTAMP_NTZ AS first_seen_at
+FROM alias_rows
+
+UNION ALL
+
+SELECT
+    source_person_id::VARCHAR AS source_person_id,
+    person_id::NUMBER(38, 0) AS person_id,
+    person_seq::NUMBER(38, 0) AS person_seq,
+    sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+    birth_year::NUMBER(38, 0) AS birth_year,
+    birth_month::NUMBER(38, 0) AS birth_month,
+    source_feed::VARCHAR AS source_feed,
+    match_method::VARCHAR AS match_method,
+    review_reason::VARCHAR AS review_reason,
+    first_seen_at::TIMESTAMP_NTZ AS first_seen_at
+FROM minted_rows
+
+{% else %}
+
+assignment_units AS (
+    SELECT
+        CASE
+            WHEN cluster_eligible
+                THEN (
+                    'SKDOB:' || sk_patient_id::VARCHAR
+                    || ':' || birth_year::VARCHAR
+                    || ':' || birth_month::VARCHAR
+                )
+            ELSE 'SRC:' || source_person_id
+        END::VARCHAR AS assignment_key,
+        MIN(source_person_id)::VARCHAR AS unit_order_key
+    FROM new_sources
+    GROUP BY assignment_key
+),
+
+numbered_units AS (
+    SELECT
+        assignment_key::VARCHAR AS assignment_key,
+        DENSE_RANK() OVER (
+            ORDER BY unit_order_key, assignment_key
+        )::NUMBER(38, 0) AS person_seq
+    FROM assignment_units
+),
+
+assigned_rows AS (
+    SELECT
+        src.source_person_id::VARCHAR AS source_person_id,
+        (100000000 + numbered_units.person_seq)::NUMBER(38, 0) AS person_id,
+        numbered_units.person_seq::NUMBER(38, 0) AS person_seq,
+        src.sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+        src.birth_year::NUMBER(38, 0) AS birth_year,
+        src.birth_month::NUMBER(38, 0) AS birth_month,
+        src.source_feed::VARCHAR AS source_feed,
+        CASE
+            WHEN src.cluster_eligible THEN 'sk_dob_cluster'
+            ELSE 'minted'
+        END::VARCHAR AS match_method,
+        src.review_reason::VARCHAR AS review_reason,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ AS first_seen_at
+    FROM new_sources AS src
+    INNER JOIN numbered_units
+        ON CASE
+            WHEN src.cluster_eligible
+                THEN (
+                    'SKDOB:' || src.sk_patient_id::VARCHAR
+                    || ':' || src.birth_year::VARCHAR
+                    || ':' || src.birth_month::VARCHAR
+                )
+            ELSE 'SRC:' || src.source_person_id
+        END = numbered_units.assignment_key
+)
+
+SELECT
+    source_person_id::VARCHAR AS source_person_id,
+    person_id::NUMBER(38, 0) AS person_id,
+    person_seq::NUMBER(38, 0) AS person_seq,
+    sk_patient_id::NUMBER(38, 0) AS sk_patient_id,
+    birth_year::NUMBER(38, 0) AS birth_year,
+    birth_month::NUMBER(38, 0) AS birth_month,
+    source_feed::VARCHAR AS source_feed,
+    match_method::VARCHAR AS match_method,
+    review_reason::VARCHAR AS review_reason,
+    first_seen_at::TIMESTAMP_NTZ AS first_seen_at
+FROM assigned_rows
+
+{% endif %}

--- a/models/indexes/person_id_index.sql
+++ b/models/indexes/person_id_index.sql
@@ -164,11 +164,16 @@ classified_sources AS (
         src.is_resolvable::BOOLEAN AS is_resolvable,
         COALESCE(key_stats.cluster_size, 0)::NUMBER(38, 0) AS cluster_size,
         COALESCE(sk_stats.sk_source_count, 0)::NUMBER(38, 0) AS sk_source_count,
+        -- cap at 5: real registration churn yields a handful of duplicate person
+        -- records; larger groups are catch-all identities (e.g. 78 'people' born
+        -- 1911-02 across 71 practices) and must never merge
         (
             src.is_resolvable
-            AND COALESCE(key_stats.cluster_size, 0) > 1
+            AND COALESCE(key_stats.cluster_size, 0) BETWEEN 2 AND 5
         )::BOOLEAN AS cluster_eligible,
         CASE
+            WHEN src.is_resolvable
+                AND COALESCE(key_stats.cluster_size, 0) > 5 THEN 'oversize_cluster'
             WHEN src.sk_count > 1 THEN 'multi_sk'
             WHEN src.dob_count > 1 THEN 'ambiguous_dob'
             WHEN src.is_resolvable
@@ -216,7 +221,8 @@ existing_candidates AS (
         birth_month::NUMBER(38, 0) AS birth_month,
         COUNT(DISTINCT person_id)::NUMBER(38, 0) AS candidate_count,
         MIN(person_id)::NUMBER(38, 0) AS candidate_person_id,
-        MIN(person_seq)::NUMBER(38, 0) AS candidate_person_seq
+        MIN(person_seq)::NUMBER(38, 0) AS candidate_person_seq,
+        COUNT(*)::NUMBER(38, 0) AS candidate_member_count
     FROM {{ this }}
     WHERE sk_patient_id IS NOT NULL
         AND birth_year IS NOT NULL
@@ -246,6 +252,7 @@ new_with_candidates AS (
         COALESCE(candidates.candidate_count, 0)::NUMBER(38, 0) AS candidate_count,
         candidates.candidate_person_id::NUMBER(38, 0) AS candidate_person_id,
         candidates.candidate_person_seq::NUMBER(38, 0) AS candidate_person_seq,
+        COALESCE(candidates.candidate_member_count, 0)::NUMBER(38, 0) AS candidate_member_count,
         COALESCE(existing_sk_stats.existing_sk_person_count, 0)::NUMBER(38, 0) AS existing_sk_person_count,
         src.review_reason::VARCHAR AS source_review_reason
     FROM new_sources AS src
@@ -270,8 +277,10 @@ alias_rows AS (
         NULL::VARCHAR AS review_reason,
         CURRENT_TIMESTAMP()::TIMESTAMP_NTZ AS first_seen_at
     FROM new_with_candidates
+    -- alias only into clusters still under the plausibility cap
     WHERE is_resolvable
         AND candidate_count = 1
+        AND candidate_member_count < 5
 ),
 
 to_mint AS (
@@ -291,6 +300,7 @@ to_mint AS (
     WHERE NOT (
         is_resolvable
         AND candidate_count = 1
+        AND candidate_member_count < 5
     )
 ),
 
@@ -325,6 +335,9 @@ mint_classified AS (
         COALESCE(new_key_stats.new_cluster_size, 0)::NUMBER(38, 0) AS new_cluster_size,
         CASE
             WHEN mint.candidate_count > 1 THEN 'ambiguous_candidates'
+            WHEN mint.candidate_count = 1 THEN 'oversize_cluster'
+            WHEN mint.is_resolvable
+                AND COALESCE(new_key_stats.new_cluster_size, 0) > 5 THEN 'oversize_cluster'
             WHEN mint.sk_count > 1 THEN 'multi_sk'
             WHEN mint.dob_count > 1 THEN 'ambiguous_dob'
             WHEN mint.is_resolvable
@@ -337,7 +350,7 @@ mint_classified AS (
         END::VARCHAR AS review_reason,
         (
             mint.is_resolvable
-            AND COALESCE(new_key_stats.new_cluster_size, 0) > 1
+            AND COALESCE(new_key_stats.new_cluster_size, 0) BETWEEN 2 AND 5
         )::BOOLEAN AS new_cluster_eligible
     FROM to_mint AS mint
     LEFT JOIN new_key_stats

--- a/models/indexes/schema.yml
+++ b/models/indexes/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: person_id_index
-    description: Append-only person id assignment table. Loss rotates surfaced person ids; `full_refresh=false` protects the state.
+    description: Append-only person identity table. Aliases share a person_id when patient sk and DOB agree.
     columns:
       - name: source_person_id
         description: Raw source person UUID.
@@ -10,16 +10,36 @@ models:
           - not_null
           - unique
       - name: person_seq
-        description: Assignment order, starting at 1.
+        description: Cluster assignment order, starting at 1.
         tests:
           - not_null
       - name: person_id
         description: Nine-digit surfaced person key.
         tests:
           - not_null
-          - unique
+      - name: sk_patient_id
+        description: Patient sk used for identity resolution.
+      - name: birth_year
+        description: Patient birth year used for identity resolution.
+      - name: birth_month
+        description: Patient birth month used for identity resolution.
       - name: source_feed
         description: First feed that introduced the source id.
+      - name: match_method
+        description: How the person_id was assigned.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['minted', 'sk_dob_cluster', 'sk_dob_alias']
+      - name: review_reason
+        description: Reason the row was not resolved cleanly.
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['multi_sk', 'ambiguous_dob', 'sk_dob_mismatch', 'ambiguous_candidates']
+              config:
+                where: "review_reason IS NOT NULL"
       - name: first_seen_at
         description: Assignment timestamp.
 

--- a/models/indexes/schema.yml
+++ b/models/indexes/schema.yml
@@ -37,7 +37,7 @@ models:
         tests:
           - accepted_values:
               arguments:
-                values: ['multi_sk', 'ambiguous_dob', 'sk_dob_mismatch', 'ambiguous_candidates']
+                values: ['multi_sk', 'ambiguous_dob', 'sk_dob_mismatch', 'ambiguous_candidates', 'oversize_cluster']
               config:
                 where: "review_reason IS NOT NULL"
       - name: first_seen_at

--- a/models/olids/conformed/conformed_person.sql
+++ b/models/olids/conformed/conformed_person.sql
@@ -69,3 +69,9 @@ WHERE EXISTS (
     FROM {{ ref('conformed_patient_person') }} AS pp
     WHERE pp.person_uuid = src.id
 )
+-- identity resolution can map several source person records to one person_id;
+-- the person table carries one canonical row per person (latest record wins)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY person_idx.person_id
+    ORDER BY src.lds_transform_datetime DESC NULLS LAST, src.id
+) = 1

--- a/models/olids/conformed/conformed_referral_request.sql
+++ b/models/olids/conformed/conformed_referral_request.sql
@@ -88,3 +88,10 @@ LEFT JOIN {{ ref('int_enriched_concept_map') }} AS specialty_map
     ON
         src.referral_request_specialty_source_concept_id
         = specialty_map.source_concept_id
+-- upstream REFERRAL_REQUEST carries versioned duplicate ids; keep the latest
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY src.id
+    ORDER BY
+        src.lds_transform_datetime DESC NULLS LAST,
+        src.recorded_date DESC NULLS LAST
+) = 1

--- a/models/olids/stable/schema.yml
+++ b/models/olids/stable/schema.yml
@@ -127,11 +127,11 @@ models:
           - unique
           - not_null
   - name: stable_patient_uprn
-    description: Stable patient_uprn table.
+    description: Stable patient_uprn table. Grain is one row per address match
+      attempt; an address accrues multiple rows across matching runs.
     columns:
       - name: patient_address_id
         tests:
-          - unique
           - not_null
   - name: stable_person
     description: Stable person table.

--- a/models/synapse/base/synapse_base_olids_person.sql
+++ b/models/synapse/base/synapse_base_olids_person.sql
@@ -80,11 +80,12 @@ WHERE
         FROM {{ ref('synapse_base_olids_patient_person') }} AS pp
         WHERE pp.person_uuid = per.id
     )
--- legacy PERSON carries versioned duplicate ids; the old incremental merge
--- deduplicated implicitly, full replace must do it explicitly (keep latest)
+-- one canonical row per surfaced person_id: covers legacy PERSON's versioned
+-- duplicate ids AND identity resolution collapsing several records to one person
 QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY per.id
+    PARTITION BY person_idx.person_id
     ORDER BY
         per.lds_start_datetime DESC NULLS LAST,
-        per.lds_datetime_update_acquired_person DESC NULLS LAST
+        per.lds_datetime_update_acquired_person DESC NULLS LAST,
+        per.id
 ) = 1

--- a/tests/assert_index_completeness.sql
+++ b/tests/assert_index_completeness.sql
@@ -1,3 +1,5 @@
+-- completeness contract matches mint-on-attributes: every person seen on
+-- PATIENT rows is indexed; person-table-only ids deliberately are not
 WITH person_sources AS (
     SELECT person_id::VARCHAR AS source_person_id
     FROM {{ ref('landing_patient') }}
@@ -5,21 +7,9 @@ WITH person_sources AS (
 
     UNION DISTINCT
 
-    SELECT id::VARCHAR AS source_person_id
-    FROM {{ ref('landing_person') }}
-    WHERE id IS NOT NULL
-
-    UNION DISTINCT
-
     SELECT person_id::VARCHAR AS source_person_id
     FROM {{ source('olids_masked', 'PATIENT') }}
     WHERE person_id IS NOT NULL
-
-    UNION DISTINCT
-
-    SELECT id::VARCHAR AS source_person_id
-    FROM {{ source('olids_masked', 'PERSON') }}
-    WHERE id IS NOT NULL
 ),
 
 patient_sources AS (

--- a/tests/assert_person_id_cluster_integrity.sql
+++ b/tests/assert_person_id_cluster_integrity.sql
@@ -1,0 +1,26 @@
+WITH keyed_members AS (
+    SELECT
+        person_id,
+        sk_patient_id,
+        birth_year,
+        birth_month
+    FROM {{ ref('person_id_index') }}
+    WHERE
+        sk_patient_id IS NOT NULL
+        AND birth_year IS NOT NULL
+        AND birth_month IS NOT NULL
+)
+
+SELECT
+    person_id,
+    COUNT(
+        DISTINCT
+        sk_patient_id::VARCHAR
+        || '-'
+        || birth_year::VARCHAR
+        || '-'
+        || birth_month::VARCHAR
+    ) AS identity_key_count
+FROM keyed_members
+GROUP BY person_id
+HAVING identity_key_count > 1


### PR DESCRIPTION
Closes #261. Refs #259, #249.

## What

person_id_index becomes an identity resolution table: source person ids resolve on sk_patient_id corroborated by patient-level birth month/year, so the same canonical person carries one person_id across feeds.

- **Resolution rules**: merge only when unambiguous (exactly one sk, exactly one DOB, cluster of plausible size); every ambiguity mints with a typed review_reason (multi_sk, ambiguous_dob, sk_dob_mismatch, oversize_cluster, ambiguous_candidates). Wrong merge = clinical safety error; missed merge = linkable duplicate.
- **Plausibility cap at five members**: the raw feed contains catch-all identities (one sk 'born 1911-02' across 71 practices binding 78 records) that must never merge.
- **Mint-on-attributes**: ids are only assigned to persons seen on patient rows. Person-table-only ids carry no attributes and would permanently split from their cross-feed twins once their practice lands (append-only never re-resolves). Persons without a registration never surface downstream.
- **Person tables canonicalise** to one row per surfaced person_id; grain fixes for upstream quirks found on first real data (REFERRAL_REQUEST versioned duplicate ids, PATIENT_UPRN match-attempt grain).
- Incremental arrivals alias only to exactly one existing candidate under the cap; existing rows are never updated.

## Verified on real data (entitlements landed mid-branch)

- 325,550 new-feed persons resolved to the same identity as their synapse records — the cross-feed property working at scale, 70% of everyone arriving with enough detail to match.
- 119 within-feed duplicates collapsed; ~2,000 flagged for review with reasons; 99.9% clean.
- Full pipeline over 293M observations builds in ~20 minutes; all grain, accepted-values, completeness and cluster-integrity tests green.
- 100% concept-mapping coverage on 282M observations (also closes the #256 investigation, closed separately with evidence).

## Notes

- Index tables remain the deliberate stateful exception: append-only, full_refresh disabled, explicit types.
- Adjudication overrides (merge/split decided by humans, applied retroactively via full replace) are the designed follow-up on #261's comments.
- dbt-analytics consumers are unaffected until the cutover (#257).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved person matching to use multiple identity attributes and clearer resolution rules.
  * Added review flags for ambiguous or conflicting matches.
  * Introduced new checks to verify cluster consistency.

* **Bug Fixes**
  * Reduced duplicate person and referral records by keeping the latest valid version.
  * Updated canonical person output so each person appears once.
  * Refined incremental processing to avoid reprocessing existing source records.

* **Tests**
  * Added validation for person ID cluster integrity.
  * Updated completeness checks for person identifier coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->