### PR TITLE
fix: expanded feed drops publisher_organisation_code on three tables

### DIFF
--- a/models/olids/conformed/conformed_organisation.sql
+++ b/models/olids/conformed/conformed_organisation.sql
@@ -5,8 +5,10 @@
 }}
 
 /*
-Conformed ORGANISATION view.
-Restricts to WNL organisations using publisher organisation code.
+Conformed ORGANISATION reference view.
+Unfiltered: the feed no longer attributes organisation records to a
+publisher, so a WNL restriction is not possible. The fuller reference
+set improves organisation id resolution downstream.
 */
 
 SELECT
@@ -23,9 +25,6 @@ SELECT
     src.close_date,
     src.is_obsolete,
     src.lds_is_deleted,
-    src.publisher_organisation_code,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_organisation') }} AS src
-INNER JOIN {{ ref('int_wnl_practices') }} AS wnl_practices
-    ON src.publisher_organisation_code = wnl_practices.practice_code

--- a/models/olids/conformed/conformed_practitioner.sql
+++ b/models/olids/conformed/conformed_practitioner.sql
@@ -21,10 +21,13 @@ SELECT
     src.name,
     src.is_obsolete,
     src.lds_is_deleted,
-    src.publisher_organisation_code,
+    -- derived: the feed no longer carries publisher_organisation_code
+    pub.organisation_code AS publisher_organisation_code,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_practitioner') }} AS src
+LEFT JOIN {{ ref('landing_organisation') }} AS pub
+    ON src.publisher_organisation_id = pub.id
 WHERE src.id IN (
     SELECT DISTINCT practitioner_id
     FROM {{ ref('conformed_practitioner_in_role') }}

--- a/models/olids/conformed/conformed_practitioner_in_role.sql
+++ b/models/olids/conformed/conformed_practitioner_in_role.sql
@@ -6,7 +6,9 @@
 
 /*
 Conformed PRACTITIONER_IN_ROLE view.
-Restricts to WNL practices.
+Restricts to WNL practices. The feed no longer carries
+publisher_organisation_code, so it is derived via publisher_organisation_id
+to keep the published interface unchanged.
 */
 
 SELECT
@@ -21,9 +23,11 @@ SELECT
     src.date_employment_start,
     src.date_employment_end,
     src.lds_is_deleted,
-    src.publisher_organisation_code,
+    pub.organisation_code AS publisher_organisation_code,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_practitioner_in_role') }} AS src
+INNER JOIN {{ ref('landing_organisation') }} AS pub
+    ON src.publisher_organisation_id = pub.id
 INNER JOIN {{ ref('int_wnl_practices') }} AS wnl_practices
-    ON src.publisher_organisation_code = wnl_practices.practice_code
+    ON pub.organisation_code = wnl_practices.practice_code

--- a/models/olids/landing/landing_organisation.sql
+++ b/models/olids/landing/landing_organisation.sql
@@ -20,7 +20,6 @@ SELECT
     close_date,
     is_obsolete,
     lds_is_deleted,
-    publisher_organisation_code,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ source('olids_pseudo', 'ORGANISATION') }}

--- a/models/olids/landing/landing_practitioner.sql
+++ b/models/olids/landing/landing_practitioner.sql
@@ -18,7 +18,6 @@ SELECT
     name,
     is_obsolete,
     lds_is_deleted,
-    publisher_organisation_code,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ source('olids_pseudo', 'PRACTITIONER') }}

--- a/models/olids/landing/landing_practitioner_in_role.sql
+++ b/models/olids/landing/landing_practitioner_in_role.sql
@@ -18,7 +18,6 @@ SELECT
     date_employment_start,
     date_employment_end,
     lds_is_deleted,
-    publisher_organisation_code,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ source('olids_pseudo', 'PRACTITIONER_IN_ROLE') }}

--- a/models/olids/stable/stable_organisation.sql
+++ b/models/olids/stable/stable_organisation.sql
@@ -20,7 +20,6 @@ SELECT
     close_date,
     is_obsolete,
     lds_is_deleted,
-    publisher_organisation_code,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_organisation') }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -725,8 +725,6 @@ sources:
       data_type: BOOLEAN
     - name: lds_is_deleted
       data_type: BOOLEAN
-    - name: publisher_organisation_code
-      data_type: TEXT
     - name: source_extraction_date
       data_type: TIMESTAMP_NTZ
     - name: lds_transform_datetime
@@ -1021,8 +1019,6 @@ sources:
       data_type: BOOLEAN
     - name: lds_is_deleted
       data_type: BOOLEAN
-    - name: publisher_organisation_code
-      data_type: TEXT
     - name: source_extraction_date
       data_type: TIMESTAMP_NTZ
     - name: lds_transform_datetime
@@ -1052,8 +1048,6 @@ sources:
       data_type: DATE
     - name: lds_is_deleted
       data_type: BOOLEAN
-    - name: publisher_organisation_code
-      data_type: TEXT
     - name: source_extraction_date
       data_type: TIMESTAMP_NTZ
     - name: lds_transform_datetime

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -2,4 +2,7 @@ packages:
 - package: dbt-labs/dbt_utils
   name: dbt_utils
   version: 1.3.0
-sha1_hash: 8067dd74fb58d3d05a437ab1975d5eeeaf3d8bea
+- package: elementary-data/elementary
+  name: elementary
+  version: 0.25.1
+sha1_hash: aa098f58d9ecf0563bada004177ef629aaf8ecee


### PR DESCRIPTION
Fixes #269

The 2026-07-15 expanded Data_Store_OLIDS_WNL delivery (285 practices) removed `publisher_organisation_code` from ORGANISATION, PRACTITIONER and PRACTITIONER_IN_ROLE, failing the three landing models in the nightly build (conformed/stable dependents skipped as designed).

- **Landing**: column dropped from the three models and sources.yml.
- **conformed_practitioner_in_role**: WNL restriction rewired via `publisher_organisation_id -> organisation.organisation_code`; the code column is derived from the same join, so the stable interface is unchanged.
- **conformed_practitioner**: same derivation for the passthrough column; role-based filter unchanged.
- **conformed_organisation**: now an unfiltered reference view — the feed carries no publisher attribution for organisations, so no WNL restriction is possible. `stable_organisation` loses `publisher_organisation_code` (downstream interface change). Side effect: the fuller reference set improves referral recipient and location managing-organisation resolution, both known RI gaps.

## Validation

`dbt build -s landing_organisation+ landing_practitioner+ landing_practitioner_in_role+` against the expanded feed: 18/18 success (9 models, 6 tests) including stable grain tests.