### PR TITLE
feat: expanded-feed recalibration, dedupes and schema alignment tests

### DIFF
--- a/models/olids/audit/schema.yml
+++ b/models/olids/audit/schema.yml
@@ -10,14 +10,14 @@ models:
       - audit_metric_within_band:
           arguments:
             metric: unlinked_live_patients
-            min_value: 90000
-            max_value: 125000
+            min_value: 800000
+            max_value: 1200000
           config:
             severity: warn
       - audit_metric_within_band:
           arguments:
             metric: unlinked_live_null_sk
-            max_value: 10000
+            max_value: 15000
           config:
             severity: warn
 
@@ -65,7 +65,7 @@ models:
       - audit_metric_within_band:
           arguments:
             metric: patient_orphan_rows
-            max_value: 2500000
+            max_value: 30000000
           config:
             severity: warn
 
@@ -83,8 +83,8 @@ models:
       - audit_metric_within_band:
           arguments:
             metric: duplicate_id_rows
-            min_value: 200000
-            max_value: 400000
+            min_value: 8000000
+            max_value: 20000000
           config:
             severity: warn
 
@@ -106,7 +106,7 @@ models:
   - name: audit_staleness
     description: >-
       Domain staleness metrics. One row per table_name, metric_name, practice_code and value_text.
-      Warns above five practices lagging the domain consensus by seven days. Consensus is the
+      Warns above thirty practices lagging the domain consensus by seven days. Consensus is the
       median of per-practice max activity dates; rows dated after their own source_extraction_date
       are excluded, so future-dated source rows cannot distort it. No CURRENT_DATE is used.
 
@@ -115,20 +115,20 @@ models:
           arguments:
             metric: practices_lagging_consensus_7d
             table_name: OBSERVATION
-            max_value: 5
+            max_value: 30
           config:
             severity: warn
       - audit_metric_within_band:
           arguments:
             metric: practices_lagging_consensus_7d
             table_name: MEDICATION_ORDER
-            max_value: 5
+            max_value: 30
           config:
             severity: warn
       - audit_metric_within_band:
           arguments:
             metric: practices_lagging_consensus_7d
             table_name: EPISODE_OF_CARE
-            max_value: 5
+            max_value: 30
           config:
             severity: warn

--- a/models/olids/conformed/conformed_appointment.sql
+++ b/models/olids/conformed/conformed_appointment.sql
@@ -81,3 +81,8 @@ LEFT JOIN {{ ref('int_enriched_concept_map') }} AS contact_mode_map
 WHERE
     src.patient_id IS NOT NULL
     AND src.start_date IS NOT NULL
+-- the feed occasionally ships exact duplicate rows; keep one deterministically
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY src.id
+    ORDER BY src.lds_transform_datetime DESC, src.lds_source_record_id
+) = 1

--- a/models/olids/conformed/conformed_observation.sql
+++ b/models/olids/conformed/conformed_observation.sql
@@ -78,3 +78,8 @@ LEFT JOIN {{ ref('int_enriched_concept_map') }} AS result_unit_map
         src.result_value_units_source_concept_id
         = result_unit_map.source_concept_id
 WHERE src.observation_source_concept_id IS NOT NULL
+-- the feed occasionally ships exact duplicate rows; keep one deterministically
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY src.id
+    ORDER BY src.lds_transform_datetime DESC, src.lds_source_record_id
+) = 1

--- a/models/olids/conformed/conformed_patient.sql
+++ b/models/olids/conformed/conformed_patient.sql
@@ -58,3 +58,8 @@ WHERE
     AND src.is_spine_sensitive = FALSE
     AND src.is_confidential = FALSE
     AND src.is_test_patient = FALSE
+-- the feed occasionally ships exact duplicate patient rows; keep one deterministically
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY src.id
+    ORDER BY src.lds_transform_datetime DESC, src.lds_source_record_id
+) = 1

--- a/models/olids/conformed/schema.yml
+++ b/models/olids/conformed/schema.yml
@@ -288,7 +288,7 @@ models:
       - null_count_below:
           arguments:
             column_name: person_id
-            max_nulls: 500
+            max_nulls: 5000
           config:
             severity: error
     columns:

--- a/models/olids/landing/schema.yml
+++ b/models/olids/landing/schema.yml
@@ -8,7 +8,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 8000000
+            min_rows: 100000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -46,7 +46,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 50000000
+            min_rows: 500000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -66,7 +66,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 300000
+            min_rows: 4000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -89,7 +89,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 40000000
+            min_rows: 400000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -127,7 +127,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 150000000
+            min_rows: 1500000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -150,7 +150,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 250000
+            min_rows: 4000000
           config:
             severity: error
       - elementary.volume_anomalies:
@@ -176,7 +176,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 200000
+            min_rows: 3000000
           config:
             severity: error
 
@@ -188,7 +188,7 @@ models:
     tests:
       - min_row_count:
           arguments:
-            min_rows: 1500000
+            min_rows: 2500000
           config:
             severity: error
 

--- a/tests/assert_landing_columns_exist_in_source.sql
+++ b/tests/assert_landing_columns_exist_in_source.sql
@@ -1,0 +1,33 @@
+-- Every landing column must still exist on its source object.
+-- A hit means the feed dropped or renamed a column the landing cache
+-- carries: the next landing build will fail. Runs before landing in
+-- dbt build, so drift is named before warehouse time is spent.
+-- Landing aliases match source table names one to one.
+
+{% set src_db = source('olids_pseudo', 'PATIENT').database %}
+
+WITH source_columns AS (
+    SELECT
+        table_name,
+        column_name
+    FROM "{{ src_db }}".information_schema.columns
+    WHERE table_schema = 'OLIDS_PSEUDO'
+),
+
+landing_columns AS (
+    SELECT
+        table_name,
+        column_name
+    FROM "{{ target.database }}".information_schema.columns
+    WHERE table_schema = 'LANDING'
+)
+
+SELECT
+    l.table_name,
+    l.column_name
+FROM landing_columns AS l
+LEFT JOIN source_columns AS s
+    ON l.table_name = s.table_name AND l.column_name = s.column_name
+WHERE
+    s.column_name IS NULL
+    AND l.table_name IN (SELECT table_name FROM source_columns)

--- a/tests/assert_source_columns_captured_in_landing.sql
+++ b/tests/assert_source_columns_captured_in_landing.sql
@@ -1,0 +1,34 @@
+{{ config(severity='warn') }}
+
+-- Every source column should be captured by its landing cache.
+-- A hit means the feed added (or renamed) a column landing does not
+-- yet select: new data is flowing that we silently ignore. Warn only;
+-- adopt the column or record the exclusion here.
+
+{% set src_db = source('olids_pseudo', 'PATIENT').database %}
+
+WITH source_columns AS (
+    SELECT
+        table_name,
+        column_name
+    FROM "{{ src_db }}".information_schema.columns
+    WHERE table_schema = 'OLIDS_PSEUDO'
+),
+
+landing_columns AS (
+    SELECT
+        table_name,
+        column_name
+    FROM "{{ target.database }}".information_schema.columns
+    WHERE table_schema = 'LANDING'
+)
+
+SELECT
+    s.table_name,
+    s.column_name
+FROM source_columns AS s
+LEFT JOIN landing_columns AS l
+    ON s.table_name = l.table_name AND s.column_name = l.column_name
+WHERE
+    l.column_name IS NULL
+    AND s.table_name IN (SELECT table_name FROM landing_columns)


### PR DESCRIPTION
Refs #265, #269. Stacked on #270 — merge that first; GitHub retargets this to main. Together they take the 285-practice expanded feed to a fully green `dbt build --exclude tag:synapse`, so DATA_LAKE.OLIDS_EXPERIMENTAL serves fresh expanded data.

## What

**Recalibration to the expanded feed** (285 practices, 5.44M patients): audit warn bands (person linkage 800k–1.2M, referral duplicates 8M–20M, appointment orphans 30M, staleness 30 practices), landing volume floors raised to ~60% of observed volumes, person-linkage gate at 5,000 residual nulls (observed 2,165 = 0.04%, same rate as the 15-practice baseline).

**Deterministic dedupes** on conformed patient, observation and appointment. The feed ships exact duplicate rows (verified `hash(*)`-identical: PATIENT 2, OBSERVATION 768, APPOINTMENT 16). Two duplicate patient rows fanned out through the `conformed_patient` inner join into thirteen stable grain-test failures — the patient dedupe alone collapses ten of them.

**Schema alignment tests**: two singular tests compare LANDING with the source's information_schema. Error severity when a landing column vanished upstream (runs before landing in `dbt build`, so drift is named before any warehouse scan); warn severity when the source gains a column we do not capture. Yesterday's #269 breakage would have been a single named test failure.

## Referral duplicates: verified upstream fan-out, no data loss

REFERRAL_REQUEST carries 14.1M duplicated ids with conflicting versions (max 8 copies). Verified across all 14,105,816: each id has exactly one source record, and `requester_organisation_id` is the only differing column — an upstream join fan-out against an organisation dimension without grain (ORGANISATION at 3.87M rows; PRACTITIONER and PRACTITIONER_IN_ROLE both at 256.9M rows look like the same class). The existing conformed dedupe therefore discards no clinical content. Defect to raise with OneLondon.

## Validation

- Full `dbt build --exclude tag:synapse tag:landing` against the expanded feed: 185/198, zero warns, the 13 failures all being the grain tests above
- After dedupes: rebuild of `conformed_patient+`: **70/70 success**
- Alignment tests pass both directions (landing exactly matches source post-#270)

## Timing note

Expanded-feed build wall time: ~9 min landing + ~25–30 min conformed/stable on the L warehouse; `LANDING.OBSERVATION` (803 GB source scan, 7m29s) and the big stable copies dominate. Spill is negligible except the clustered insert on `stable_appointment_practitioner` (17 GB local) — a candidate to drop clustering on link tables later.