### PR TITLE
feat: clinical_system attribution, FRESHNESS table and data_lake deploy hook

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,6 +8,9 @@ profile: 'dbt_olids'
 on-run-start:
   - "{{ log('🔗 DBT CONNECTION: Role=' ~ target.role ~ ', Warehouse=' ~ target.warehouse ~ ', Database=' ~ target.database ~ ', Schema=' ~ target.schema ~ ', Target=' ~ target.name, info=True) }}"
 
+on-run-end:
+  - "{{ deploy_data_lake_views() }}"
+
 target-path: "target"
 clean-targets:
   - "target"

--- a/macros/deploy_data_lake_views.sql
+++ b/macros/deploy_data_lake_views.sql
@@ -1,0 +1,16 @@
+{% macro deploy_data_lake_views() %}
+    {% if execute and flags.WHICH in ('run', 'build') %}
+        {% set stable_built = [] %}
+        {% for r in results %}
+            {% if r.status == 'success' and r.node.resource_type == 'model'
+                  and r.node.schema | lower in ('olids_stable', 'stable') %}
+                {% do stable_built.append(r.node.name) %}
+            {% endif %}
+        {% endfor %}
+        {% if stable_built | length > 0 %}
+            {# Snowflake forbids mixing positional and named arguments: all named #}
+            {% do run_query("CALL DATA_LAKE.CONTROL.DEPLOY_DATA_LAKE_VIEWS_FOR_SINGLE_SOURCE_MAPPING(SOURCE_DATABASE => 'OLIDS_ENGINEERING', SOURCE_SCHEMA => 'STABLE', DESTINATION_SCHEMA => 'OLIDS_EXPERIMENTAL', FORCE_DEPLOY => TRUE)") %}
+            {% do log('data_lake OLIDS_EXPERIMENTAL views redeployed (' ~ stable_built | length ~ ' stable models built)', info=True) %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/models/olids/conformed/conformed_allergy_intolerance.sql
+++ b/models/olids/conformed/conformed_allergy_intolerance.sql
@@ -46,6 +46,7 @@ SELECT
     src.is_confidential,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_allergy_intolerance') }} AS src

--- a/models/olids/conformed/conformed_appointment.sql
+++ b/models/olids/conformed/conformed_appointment.sql
@@ -57,6 +57,7 @@ SELECT
     src.csds_care_contact_identifier,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_appointment') }} AS src

--- a/models/olids/conformed/conformed_diagnostic_order.sql
+++ b/models/olids/conformed/conformed_diagnostic_order.sql
@@ -50,6 +50,7 @@ SELECT
     src.date_recorded,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_diagnostic_order') }} AS src

--- a/models/olids/conformed/conformed_encounter.sql
+++ b/models/olids/conformed/conformed_encounter.sql
@@ -47,6 +47,7 @@ SELECT
     src.admission_method,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_encounter') }} AS src

--- a/models/olids/conformed/conformed_episode_of_care.sql
+++ b/models/olids/conformed/conformed_episode_of_care.sql
@@ -35,6 +35,7 @@ SELECT
     episode_status_map.target_display AS episode_status_display,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_episode_of_care') }} AS src

--- a/models/olids/conformed/conformed_medication_order.sql
+++ b/models/olids/conformed/conformed_medication_order.sql
@@ -62,6 +62,7 @@ SELECT
     src.issue_method_description,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_medication_order') }} AS src

--- a/models/olids/conformed/conformed_medication_statement.sql
+++ b/models/olids/conformed/conformed_medication_statement.sql
@@ -64,6 +64,7 @@ SELECT
     src.expiry_date,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_medication_statement') }} AS src

--- a/models/olids/conformed/conformed_observation.sql
+++ b/models/olids/conformed/conformed_observation.sql
@@ -56,6 +56,7 @@ SELECT
     src.is_confidential,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_observation') }} AS src

--- a/models/olids/conformed/conformed_patient.sql
+++ b/models/olids/conformed/conformed_patient.sql
@@ -38,6 +38,14 @@ SELECT
     src.is_test_patient,
     src.is_spine_sensitive,
     src.lds_source_dataset,
+    CASE
+        WHEN src.lds_source_dataset ILIKE '%emis%' THEN 'EMIS'
+        WHEN
+            src.lds_source_dataset ILIKE '%tpp%'
+            OR src.lds_source_dataset ILIKE '%systmone%'
+            THEN 'SystmOne'
+        ELSE src.lds_source_dataset
+    END AS clinical_system,
     src.lds_is_deleted,
     src.publisher_organisation_code,
     src.source_extraction_date,

--- a/models/olids/conformed/conformed_patient_address.sql
+++ b/models/olids/conformed/conformed_patient_address.sql
@@ -24,6 +24,7 @@ SELECT
     src.end_date,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_patient_address') }} AS src

--- a/models/olids/conformed/conformed_patient_contact.sql
+++ b/models/olids/conformed/conformed_patient_contact.sql
@@ -22,6 +22,7 @@ SELECT
     src.end_date,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_patient_contact') }} AS src

--- a/models/olids/conformed/conformed_patient_person.sql
+++ b/models/olids/conformed/conformed_patient_person.sql
@@ -19,7 +19,8 @@ SELECT
     src.lds_source_record_id_person,
     src.gp_practice_code,
     src.lds_is_deleted,
-    src.lds_transform_datetime
+    src.lds_transform_datetime,
+    patients.clinical_system
 FROM {{ ref('landing_patient_person') }} AS src
 INNER JOIN {{ ref('conformed_patient') }} AS patients
     ON src.patient_id = patients.source_id

--- a/models/olids/conformed/conformed_person.sql
+++ b/models/olids/conformed/conformed_person.sql
@@ -12,7 +12,8 @@ Keeps people linked to the filtered patient spine and passes pseudonymised field
 WITH gender_fallback AS (
     SELECT
         pp.person_uuid,
-        c.display AS gender
+        c.display AS gender,
+        pat.clinical_system
     FROM {{ ref('conformed_patient_person') }} AS pp
     INNER JOIN {{ ref('conformed_patient') }} AS pat
         ON pp.patient_id = pat.id
@@ -56,6 +57,8 @@ SELECT
     src.patient_flagged_sensitive,
     src.error_success_code,
     src.lds_is_deleted,
+    -- from the patient record backing this person row
+    gf.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime,
     COALESCE(src.gender, gf.gender) AS gender

--- a/models/olids/conformed/conformed_procedure_request.sql
+++ b/models/olids/conformed/conformed_procedure_request.sql
@@ -47,6 +47,7 @@ SELECT
     status_map.target_display AS status_display,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_procedure_request') }} AS src

--- a/models/olids/conformed/conformed_referral_request.sql
+++ b/models/olids/conformed/conformed_referral_request.sql
@@ -62,6 +62,7 @@ SELECT
     src.value,
     src.lds_is_deleted,
     src.publisher_organisation_code,
+    patients.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime
 FROM {{ ref('landing_referral_request') }} AS src

--- a/models/olids/conformed/schema.yml
+++ b/models/olids/conformed/schema.yml
@@ -31,6 +31,7 @@ models:
       - name: clinical_effective_date
       - name: allergy_intolerance_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
+      - name: clinical_system
   - name: conformed_appointment
     description: 'Filtered Appointment conformed view.
 
@@ -55,6 +56,7 @@ models:
       - name: appointment_status_source_concept_id
       - name: booking_method_source_concept_id
       - name: contact_mode_source_concept_id
+      - name: clinical_system
   - name: conformed_appointment_practitioner
     description: 'Filtered Appointment Practitioner conformed view.
 
@@ -97,6 +99,7 @@ models:
       - name: result_measurement_units_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
       - name: episodicity_source_concept_id
+      - name: clinical_system
   - name: conformed_encounter
     description: 'Filtered Encounter conformed view.
 
@@ -118,6 +121,7 @@ models:
       - name: clinical_effective_date
       - name: encounter_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
+      - name: clinical_system
   - name: conformed_episode_of_care
     description: 'Filtered Episode Of Care conformed view.
 
@@ -153,6 +157,7 @@ models:
       - name: episode_of_care_start_date
       - name: episode_type_source_concept_id
       - name: episode_status_source_concept_id
+      - name: clinical_system
   - name: conformed_location
     description: 'Unfiltered Location reference view.
 
@@ -200,6 +205,7 @@ models:
       - name: clinical_effective_date
       - name: medication_order_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
+      - name: clinical_system
   - name: conformed_medication_statement
     description: 'Filtered Medication Statement conformed view.
 
@@ -238,6 +244,7 @@ models:
       - name: medication_statement_source_concept_id
       - name: authorisation_type_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
+      - name: clinical_system
   - name: conformed_observation
     description: 'Filtered Observation conformed view.
 
@@ -273,6 +280,7 @@ models:
       - name: result_value_units_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
       - name: episodicity_source_concept_id
+      - name: clinical_system
   - name: conformed_organisation
     description: 'Unfiltered Organisation reference view.
 
@@ -301,6 +309,7 @@ models:
       - name: lds_source_record_id
       - name: gender_source_concept_id
       - name: registered_practice_organisation_id
+      - name: clinical_system
   - name: conformed_patient_address
     description: 'Filtered Patient Address conformed view.
 
@@ -320,6 +329,7 @@ models:
       - name: patient_id
       - name: person_id
       - name: address_type_source_concept_id
+      - name: clinical_system
   - name: conformed_patient_contact
     description: 'Filtered Patient Contact conformed view.
 
@@ -339,6 +349,7 @@ models:
       - name: patient_id
       - name: person_id
       - name: contact_type_source_concept_id
+      - name: clinical_system
   - name: conformed_patient_person
     description: 'Generated Patient Person conformed view.
 
@@ -355,6 +366,7 @@ models:
       - name: patient_id
       - name: person_id
       - name: id
+      - name: clinical_system
   - name: conformed_patient_uprn
     description: 'Unfiltered Patient Uprn reference view.
 
@@ -379,6 +391,7 @@ models:
       Identifiers: id is the indexed person id; person_uuid holds the source UUID.'
     columns:
       - name: id
+      - name: clinical_system
   - name: conformed_practitioner
     description: 'Filtered Practitioner conformed view.
 
@@ -433,6 +446,7 @@ models:
       - name: procedure_request_source_concept_id
       - name: clinical_effective_date_precision_source_concept_id
       - name: status_source_concept_id
+      - name: clinical_system
   - name: conformed_referral_request
     description: 'Filtered Referral Request conformed view.
 
@@ -466,6 +480,7 @@ models:
       - name: referral_request_priority_source_concept_id
       - name: referral_request_type_source_concept_id
       - name: referral_request_specialty_source_concept_id
+      - name: clinical_system
   - name: conformed_schedule
     description: 'Filtered Schedule conformed view.
 

--- a/models/olids/intermediate/terminology/int_enriched_concept_map.sql
+++ b/models/olids/intermediate/terminology/int_enriched_concept_map.sql
@@ -138,30 +138,79 @@ missing_emis_mappings AS (
     WHERE cm.source_concept_id IS NULL
 ),
 
+{#-
+    Fallback mappings for vocabularies the feed ships without CONCEPT_MAP rows.
+    Keyed on (system, code), never concept UUID: each environment mints its own
+    pseudonymised ids. Targets mirror the legacy feed's authoritative mappings.
+-#}
+{% set local_mappings = [
+    {'system': 'EMIS_RegistrationStatus_cs', 'code': 'Deceased',
+     'target_code': '725951000000101', 'target_display': 'GP22 deregistration - death'},
+    {'system': 'EMIS_and_TPP_MedicationStatement_cs', 'code': 'Acute',
+     'target_code': '1217105006', 'target_display': 'Prescription given'},
+    {'system': 'EMIS_and_TPP_MedicationStatement_cs', 'code': 'Automatic',
+     'target_code': '1217105006', 'target_display': 'Prescription given'},
+    {'system': 'EMIS_and_TPP_MedicationStatement_cs', 'code': 'Repeat',
+     'target_code': '182918009', 'target_display': 'Repeated prescription'},
+    {'system': 'EMIS_and_TPP_MedicationStatement_cs', 'code': 'Repeat Dispensing',
+     'target_code': '182918009', 'target_display': 'Repeated prescription'},
+] %}
+
 local_backfills AS (
-    -- fallback only: applies when the feed supplies no CONCEPT_MAP row.
-    -- keyed on (system, code), not concept UUID - each environment mints its
-    -- own pseudonymised ids (the previous hardcoded UUID was authored against
-    -- the synapse feed and matched nothing here)
+    -- fallback only: applies when the feed supplies no CONCEPT_MAP row
     SELECT
         src.concept_id AS source_concept_id,
         src.code AS source_code,
         src.display AS source_display,
         src.system AS source_system,
         NULL::VARCHAR AS target_concept_id,
-        '725951000000101' AS target_code,
-        'GP22 deregistration - death' AS target_display,
+        m.target_code,
+        m.target_display,
         'snomed_info_sct' AS target_system,
         TRUE AS is_primary,
         'local-backfill' AS equivalence,
         1 AS equivalence_rank
     FROM {{ ref('landing_concept') }} AS src
+    INNER JOIN (
+        {% for m in local_mappings %}
+        SELECT
+            '{{ m.system }}' AS system,
+            '{{ m.code }}' AS code,
+            '{{ m.target_code }}' AS target_code,
+            '{{ m.target_display }}' AS target_display
+        {% if not loop.last %}UNION ALL{% endif %}
+        {% endfor %}
+    ) AS m
+        ON src.system = m.system AND src.code = m.code
+    LEFT JOIN {{ ref('conformed_concept_map') }} AS cm
+        ON src.concept_id = cm.source_concept_id
+    WHERE cm.source_concept_id IS NULL
+),
+
+unmapped_passthrough AS (
+    -- concepts with no CONCEPT_MAP row keep their source code and display so
+    -- enumerations (date precision, address and contact types, statuses) stay
+    -- usable downstream; target side stays null, so mapping gates still count
+    -- these as unmapped. The final dedupe prefers any row with a target.
+    SELECT
+        src.concept_id AS source_concept_id,
+        src.code AS source_code,
+        src.display AS source_display,
+        src.system AS source_system,
+        NULL::VARCHAR AS target_concept_id,
+        NULL::VARCHAR AS target_code,
+        NULL::VARCHAR AS target_display,
+        NULL::VARCHAR AS target_system,
+        TRUE AS is_primary,
+        'unmapped-passthrough' AS equivalence,
+        99 AS equivalence_rank
+    FROM {{ ref('landing_concept') }} AS src
     LEFT JOIN {{ ref('conformed_concept_map') }} AS cm
         ON src.concept_id = cm.source_concept_id
     WHERE
-        src.system = 'EMIS_RegistrationStatus_cs'
-        AND src.code = 'Deceased'
-        AND cm.source_concept_id IS NULL
+        cm.source_concept_id IS NULL
+        -- honour the snomed-as-source exclusion applied to mapped rows
+        AND src.system NOT IN ('http:__snomed.info_sct', 'snomed_info_sct')
 ),
 
 unioned AS (
@@ -211,6 +260,22 @@ unioned AS (
         equivalence,
         equivalence_rank
     FROM local_backfills
+
+    UNION ALL
+
+    SELECT
+        source_concept_id,
+        source_code,
+        source_display,
+        source_system,
+        target_concept_id,
+        target_code,
+        target_display,
+        target_system,
+        is_primary,
+        equivalence,
+        equivalence_rank
+    FROM unmapped_passthrough
 )
 
 SELECT *

--- a/models/olids/stable/schema.yml
+++ b/models/olids/stable/schema.yml
@@ -7,6 +7,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_appointment
     description: Stable appointment table.
     columns:
@@ -14,6 +15,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_appointment_practitioner
     description: Stable appointment_practitioner table.
     columns:
@@ -42,6 +44,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_encounter
     description: Stable encounter table.
     columns:
@@ -49,6 +52,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_episode_of_care
     description: Stable episode_of_care table.
     columns:
@@ -56,6 +60,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_location
     description: Stable location table.
     columns:
@@ -70,6 +75,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_medication_statement
     description: Stable medication_statement table.
     columns:
@@ -77,6 +83,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_national_data_opt_out
     description: Stable national_data_opt_out table.
     columns:
@@ -91,6 +98,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_organisation
     description: Stable organisation table.
     columns:
@@ -105,6 +113,8 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
+        description: 'Clinical system that recorded the row, cascaded from the patient record (EMIS or SystmOne).'
   - name: stable_patient_address
     description: Stable patient_address table.
     columns:
@@ -112,6 +122,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_patient_contact
     description: Stable patient_contact table.
     columns:
@@ -119,6 +130,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_patient_person
     description: Stable patient_person table.
     columns:
@@ -126,6 +138,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_patient_uprn
     description: Stable patient_uprn table. Grain is one row per address match
       attempt; an address accrues multiple rows across matching runs.
@@ -140,6 +153,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_postcode_hash
     description: Stable postcode_hash table.
     columns:
@@ -168,6 +182,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_referral_request
     description: Stable referral_request table.
     columns:
@@ -175,6 +190,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: clinical_system
   - name: stable_schedule
     description: Stable schedule table.
     columns:
@@ -189,3 +205,26 @@ models:
         tests:
           - unique
           - not_null
+
+  - name: stable_freshness
+    description: 'Published freshness watermarks computed from the stable tables. Grain: one row per table_name and publisher_code (null publisher_code = table-level row). Processing watermarks (max source_extraction_date, max lds_transform_datetime) show pipeline movement; activity watermarks show content currency, excluding deleted rows and rows dated after their own extraction. Consensus is the median of publisher maxima; lag is data-to-data (no CURRENT_DATE). Tables without processing date columns carry no row.'
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - table_name
+              - publisher_code
+    columns:
+      - name: table_name
+        tests:
+          - not_null
+      - name: publisher_code
+      - name: max_source_extraction_date
+      - name: max_lds_transform_datetime
+      - name: max_activity_date
+      - name: consensus_activity_date
+      - name: activity_lag_days
+      - name: practices_reporting
+      - name: practices_lagging_consensus_7d
+      - name: practices_lagging_consensus_14d

--- a/models/olids/stable/schema.yml
+++ b/models/olids/stable/schema.yml
@@ -207,7 +207,7 @@ models:
           - not_null
 
   - name: stable_freshness
-    description: 'Published freshness watermarks computed from the stable tables. Grain: one row per table_name and publisher_code (null publisher_code = table-level row). Processing watermarks (max source_extraction_date, max lds_transform_datetime) show pipeline movement; activity watermarks show content currency, excluding deleted rows and rows dated after their own extraction. Consensus is the median of publisher maxima; lag is data-to-data (no CURRENT_DATE). Tables without processing date columns carry no row.'
+    description: 'Per-publisher freshness watermarks computed from the stable tables. Grain: one row per table_name and publisher_code, every column populated. Processing watermarks (max source_extraction_date, max lds_transform_datetime) show pipeline movement; activity watermarks show content currency, excluding deleted rows and rows dated after their own extraction. Consensus is the median of publisher maxima; lag is data-to-data (no CURRENT_DATE). Table-level rollups live in FRESHNESS_SUMMARY.'
 
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -220,11 +220,19 @@ models:
         tests:
           - not_null
       - name: publisher_code
+        tests:
+          - not_null
       - name: max_source_extraction_date
       - name: max_lds_transform_datetime
       - name: max_activity_date
       - name: consensus_activity_date
       - name: activity_lag_days
-      - name: practices_reporting
-      - name: practices_lagging_consensus_7d
-      - name: practices_lagging_consensus_14d
+
+  - name: stable_freshness_summary
+    description: 'One row per table: table-level watermarks, consensus and the worst-lagging publisher from FRESHNESS. The quick-scan view of feed health.'
+
+    columns:
+      - name: table_name
+        tests:
+          - not_null
+          - unique

--- a/models/olids/stable/stable_allergy_intolerance.sql
+++ b/models/olids/stable/stable_allergy_intolerance.sql
@@ -43,6 +43,7 @@ SELECT
     is_confidential,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_allergy_intolerance') }}

--- a/models/olids/stable/stable_appointment.sql
+++ b/models/olids/stable/stable_appointment.sql
@@ -53,6 +53,7 @@ SELECT
     csds_care_contact_identifier,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_appointment') }}

--- a/models/olids/stable/stable_diagnostic_order.sql
+++ b/models/olids/stable/stable_diagnostic_order.sql
@@ -47,6 +47,7 @@ SELECT
     date_recorded,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_diagnostic_order') }}

--- a/models/olids/stable/stable_encounter.sql
+++ b/models/olids/stable/stable_encounter.sql
@@ -43,6 +43,7 @@ SELECT
     admission_method,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_encounter') }}

--- a/models/olids/stable/stable_episode_of_care.sql
+++ b/models/olids/stable/stable_episode_of_care.sql
@@ -32,6 +32,7 @@ SELECT
     episode_status_display,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_episode_of_care') }}

--- a/models/olids/stable/stable_freshness.sql
+++ b/models/olids/stable/stable_freshness.sql
@@ -1,0 +1,150 @@
+{{
+    config(
+        materialized='table',
+        alias='FRESHNESS')
+}}
+
+/*
+Published freshness watermarks, computed from the stable tables themselves so
+they always describe exactly what consumers read: a gate-blocked build leaves
+them at the previous values rather than advertising unpublished data.
+
+Grain: one row per table_name and publisher_code; publisher_code is null for
+table-level rows. Processing watermarks say whether the pipeline is moving;
+activity watermarks say whether the clinical content is current. Activity
+excludes deleted rows and rows dated after their own extraction, and the
+table-level consensus is the median of publisher maxima, so future-dated
+source rows cannot distort it. No CURRENT_DATE: lag is data-to-data.
+
+Tables without processing date columns (concept, concept_map, postcode_hash,
+patient_uprn, national_data_opt_out) carry no freshness row.
+*/
+
+{% set tables = [
+    {'name': 'observation', 'activity': 'clinical_effective_date'},
+    {'name': 'medication_order', 'activity': 'clinical_effective_date'},
+    {'name': 'medication_statement', 'activity': 'clinical_effective_date'},
+    {'name': 'encounter', 'activity': 'clinical_effective_date'},
+    {'name': 'appointment', 'activity': 'start_date'},
+    {'name': 'episode_of_care', 'activity': 'episode_of_care_start_date'},
+    {'name': 'referral_request', 'activity': 'clinical_effective_date'},
+    {'name': 'procedure_request', 'activity': 'clinical_effective_date'},
+    {'name': 'diagnostic_order', 'activity': 'clinical_effective_date'},
+    {'name': 'allergy_intolerance', 'activity': 'clinical_effective_date'},
+    {'name': 'patient', 'activity': none},
+    {'name': 'patient_address', 'activity': none},
+    {'name': 'patient_contact', 'activity': none},
+    {'name': 'appointment_practitioner', 'activity': none},
+    {'name': 'practitioner', 'activity': none},
+    {'name': 'practitioner_in_role', 'activity': none},
+    {'name': 'schedule', 'activity': none},
+    {'name': 'schedule_practitioner', 'activity': none},
+] %}
+
+{% set table_level_only = [
+    {'name': 'location', 'ext': true},
+    {'name': 'organisation', 'ext': true},
+    {'name': 'person', 'ext': true},
+    {'name': 'patient_person', 'ext': false},
+] %}
+
+WITH per_publisher AS (
+    {% for t in tables %}
+    SELECT
+        '{{ t.name | upper }}' AS table_name,
+        publisher_organisation_code AS publisher_code,
+        MAX(source_extraction_date) AS max_source_extraction_date,
+        MAX(lds_transform_datetime) AS max_lds_transform_datetime,
+        {% if t.activity %}
+        MAX(CASE
+            WHEN
+                NOT COALESCE(lds_is_deleted, FALSE)
+                AND {{ t.activity }} <= source_extraction_date
+                THEN {{ t.activity }}
+        END)::DATE AS max_activity_date
+        {% else %}
+        NULL::DATE AS max_activity_date
+        {% endif %}
+    FROM {{ ref('stable_' ~ t.name) }}
+    WHERE publisher_organisation_code IS NOT NULL
+    GROUP BY publisher_organisation_code
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+),
+
+consensus AS (
+    SELECT
+        table_name,
+        DATEADD(
+            'day',
+            MEDIAN(DATEDIFF('day', TO_DATE('1970-01-01'), max_activity_date)),
+            TO_DATE('1970-01-01')
+        )::DATE AS consensus_activity_date,
+        COUNT(*) AS practices_reporting
+    FROM per_publisher
+    WHERE max_activity_date IS NOT NULL
+    GROUP BY table_name
+),
+
+table_level AS (
+    SELECT
+        p.table_name,
+        NULL::VARCHAR AS publisher_code,
+        MAX(p.max_source_extraction_date) AS max_source_extraction_date,
+        MAX(p.max_lds_transform_datetime) AS max_lds_transform_datetime,
+        MAX(p.max_activity_date) AS max_activity_date,
+        MAX(c.consensus_activity_date) AS consensus_activity_date,
+        MAX(c.practices_reporting) AS practices_reporting,
+        COUNT_IF(
+            DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) > 7
+        ) AS practices_lagging_consensus_7d,
+        COUNT_IF(
+            DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) > 14
+        ) AS practices_lagging_consensus_14d
+    FROM per_publisher AS p
+    LEFT JOIN consensus AS c ON p.table_name = c.table_name
+    GROUP BY p.table_name
+
+    {% for t in table_level_only %}
+    UNION ALL
+    SELECT
+        '{{ t.name | upper }}',
+        NULL,
+        {% if t.ext %}MAX(source_extraction_date){% else %}NULL{% endif %},
+        MAX(lds_transform_datetime),
+        NULL, NULL, NULL, NULL, NULL
+    FROM {{ ref('stable_' ~ t.name) }}
+    {% endfor %}
+)
+
+SELECT
+    table_name,
+    publisher_code,
+    max_source_extraction_date,
+    max_lds_transform_datetime,
+    max_activity_date,
+    consensus_activity_date,
+    -- data-to-data difference; positive means the publisher trails the consensus
+    DATEDIFF('day', max_activity_date, consensus_activity_date) AS activity_lag_days,
+    practices_reporting,
+    practices_lagging_consensus_7d,
+    practices_lagging_consensus_14d
+FROM table_level
+
+UNION ALL
+
+SELECT
+    p.table_name,
+    p.publisher_code,
+    p.max_source_extraction_date,
+    p.max_lds_transform_datetime,
+    p.max_activity_date,
+    c.consensus_activity_date,
+    DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) AS activity_lag_days,
+    NULL AS practices_reporting,
+    NULL AS practices_lagging_consensus_7d,
+    NULL AS practices_lagging_consensus_14d
+FROM per_publisher AS p
+LEFT JOIN consensus AS c ON p.table_name = c.table_name

--- a/models/olids/stable/stable_freshness.sql
+++ b/models/olids/stable/stable_freshness.sql
@@ -5,19 +5,16 @@
 }}
 
 /*
-Published freshness watermarks, computed from the stable tables themselves so
-they always describe exactly what consumers read: a gate-blocked build leaves
-them at the previous values rather than advertising unpublished data.
+Per-publisher freshness watermarks, computed from the stable tables themselves
+so they always describe exactly what consumers read: a gate-blocked build
+leaves them at the previous values rather than advertising unpublished data.
 
-Grain: one row per table_name and publisher_code; publisher_code is null for
-table-level rows. Processing watermarks say whether the pipeline is moving;
-activity watermarks say whether the clinical content is current. Activity
-excludes deleted rows and rows dated after their own extraction, and the
-table-level consensus is the median of publisher maxima, so future-dated
-source rows cannot distort it. No CURRENT_DATE: lag is data-to-data.
-
-Tables without processing date columns (concept, concept_map, postcode_hash,
-patient_uprn, national_data_opt_out) carry no freshness row.
+Grain: one row per table_name and publisher_code, every column populated.
+Processing watermarks say whether the pipeline is moving; activity watermarks
+say whether the clinical content is current. Activity excludes deleted rows
+and rows dated after their own extraction, and the consensus is the median of
+publisher maxima, so future-dated source rows cannot distort it. Lag is
+data-to-data: no CURRENT_DATE. Table-level rollups live in FRESHNESS_SUMMARY.
 */
 
 {% set tables = [
@@ -39,13 +36,6 @@ patient_uprn, national_data_opt_out) carry no freshness row.
     {'name': 'practitioner_in_role', 'activity': none},
     {'name': 'schedule', 'activity': none},
     {'name': 'schedule_practitioner', 'activity': none},
-] %}
-
-{% set table_level_only = [
-    {'name': 'location', 'ext': true},
-    {'name': 'organisation', 'ext': true},
-    {'name': 'person', 'ext': true},
-    {'name': 'patient_person', 'ext': false},
 ] %}
 
 WITH per_publisher AS (
@@ -81,59 +71,11 @@ consensus AS (
             'day',
             MEDIAN(DATEDIFF('day', TO_DATE('1970-01-01'), max_activity_date)),
             TO_DATE('1970-01-01')
-        )::DATE AS consensus_activity_date,
-        COUNT(*) AS practices_reporting
+        )::DATE AS consensus_activity_date
     FROM per_publisher
     WHERE max_activity_date IS NOT NULL
     GROUP BY table_name
-),
-
-table_level AS (
-    SELECT
-        p.table_name,
-        NULL::VARCHAR AS publisher_code,
-        MAX(p.max_source_extraction_date) AS max_source_extraction_date,
-        MAX(p.max_lds_transform_datetime) AS max_lds_transform_datetime,
-        MAX(p.max_activity_date) AS max_activity_date,
-        MAX(c.consensus_activity_date) AS consensus_activity_date,
-        MAX(c.practices_reporting) AS practices_reporting,
-        COUNT_IF(
-            DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) > 7
-        ) AS practices_lagging_consensus_7d,
-        COUNT_IF(
-            DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) > 14
-        ) AS practices_lagging_consensus_14d
-    FROM per_publisher AS p
-    LEFT JOIN consensus AS c ON p.table_name = c.table_name
-    GROUP BY p.table_name
-
-    {% for t in table_level_only %}
-    UNION ALL
-    SELECT
-        '{{ t.name | upper }}',
-        NULL,
-        {% if t.ext %}MAX(source_extraction_date){% else %}NULL{% endif %},
-        MAX(lds_transform_datetime),
-        NULL, NULL, NULL, NULL, NULL
-    FROM {{ ref('stable_' ~ t.name) }}
-    {% endfor %}
 )
-
-SELECT
-    table_name,
-    publisher_code,
-    max_source_extraction_date,
-    max_lds_transform_datetime,
-    max_activity_date,
-    consensus_activity_date,
-    -- data-to-data difference; positive means the publisher trails the consensus
-    DATEDIFF('day', max_activity_date, consensus_activity_date) AS activity_lag_days,
-    practices_reporting,
-    practices_lagging_consensus_7d,
-    practices_lagging_consensus_14d
-FROM table_level
-
-UNION ALL
 
 SELECT
     p.table_name,
@@ -142,9 +84,8 @@ SELECT
     p.max_lds_transform_datetime,
     p.max_activity_date,
     c.consensus_activity_date,
-    DATEDIFF('day', p.max_activity_date, c.consensus_activity_date) AS activity_lag_days,
-    NULL AS practices_reporting,
-    NULL AS practices_lagging_consensus_7d,
-    NULL AS practices_lagging_consensus_14d
+    -- data-to-data difference; positive means the publisher trails the consensus
+    DATEDIFF('day', p.max_activity_date, c.consensus_activity_date)
+        AS activity_lag_days
 FROM per_publisher AS p
 LEFT JOIN consensus AS c ON p.table_name = c.table_name

--- a/models/olids/stable/stable_freshness_summary.sql
+++ b/models/olids/stable/stable_freshness_summary.sql
@@ -1,0 +1,69 @@
+{{
+    config(
+        materialized='table',
+        alias='FRESHNESS_SUMMARY')
+}}
+
+/*
+One row per table: the scan view of feed health. Rolls up FRESHNESS and adds
+the worst-lagging publisher; tables without a publisher column (location,
+organisation, person, patient_person) appear with processing watermarks only.
+*/
+
+{% set table_level_only = [
+    {'name': 'location', 'ext': true},
+    {'name': 'organisation', 'ext': true},
+    {'name': 'person', 'ext': true},
+    {'name': 'patient_person', 'ext': false},
+] %}
+
+WITH rollup AS (
+    SELECT
+        table_name,
+        MAX(max_source_extraction_date) AS max_source_extraction_date,
+        MAX(max_lds_transform_datetime) AS max_lds_transform_datetime,
+        MAX(max_activity_date) AS max_activity_date,
+        MAX(consensus_activity_date) AS consensus_activity_date,
+        COUNT_IF(max_activity_date IS NOT NULL) AS practices_reporting,
+        COUNT_IF(activity_lag_days > 7) AS practices_lagging_consensus_7d,
+        COUNT_IF(activity_lag_days > 14) AS practices_lagging_consensus_14d
+    FROM {{ ref('stable_freshness') }}
+    GROUP BY table_name
+),
+
+worst_publisher AS (
+    SELECT
+        table_name,
+        publisher_code AS worst_publisher_code,
+        activity_lag_days AS worst_publisher_lag_days
+    FROM {{ ref('stable_freshness') }}
+    WHERE activity_lag_days IS NOT NULL
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY table_name
+        ORDER BY activity_lag_days DESC, publisher_code
+    ) = 1
+)
+
+SELECT
+    r.table_name,
+    r.max_source_extraction_date,
+    r.max_lds_transform_datetime,
+    r.consensus_activity_date,
+    r.max_activity_date,
+    r.practices_reporting,
+    r.practices_lagging_consensus_7d,
+    r.practices_lagging_consensus_14d,
+    w.worst_publisher_code,
+    w.worst_publisher_lag_days
+FROM rollup AS r
+LEFT JOIN worst_publisher AS w ON r.table_name = w.table_name
+
+{% for t in table_level_only %}
+UNION ALL
+SELECT
+    '{{ t.name | upper }}',
+    {% if t.ext %}MAX(source_extraction_date){% else %}NULL{% endif %},
+    MAX(lds_transform_datetime),
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL
+FROM {{ ref('stable_' ~ t.name) }}
+{% endfor %}

--- a/models/olids/stable/stable_medication_order.sql
+++ b/models/olids/stable/stable_medication_order.sql
@@ -57,6 +57,7 @@ SELECT
     issue_method_description,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_medication_order') }}

--- a/models/olids/stable/stable_medication_statement.sql
+++ b/models/olids/stable/stable_medication_statement.sql
@@ -60,6 +60,7 @@ SELECT
     expiry_date,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_medication_statement') }}

--- a/models/olids/stable/stable_observation.sql
+++ b/models/olids/stable/stable_observation.sql
@@ -52,6 +52,7 @@ SELECT
     is_confidential,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_observation') }}

--- a/models/olids/stable/stable_patient.sql
+++ b/models/olids/stable/stable_patient.sql
@@ -37,6 +37,7 @@ SELECT
     lds_source_dataset,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_patient') }}

--- a/models/olids/stable/stable_patient_address.sql
+++ b/models/olids/stable/stable_patient_address.sql
@@ -21,6 +21,7 @@ SELECT
     end_date,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_patient_address') }}

--- a/models/olids/stable/stable_patient_contact.sql
+++ b/models/olids/stable/stable_patient_contact.sql
@@ -19,6 +19,7 @@ SELECT
     end_date,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_patient_contact') }}

--- a/models/olids/stable/stable_patient_person.sql
+++ b/models/olids/stable/stable_patient_person.sql
@@ -16,5 +16,6 @@ SELECT
     lds_source_record_id_person,
     gp_practice_code,
     lds_is_deleted,
-    lds_transform_datetime
+    lds_transform_datetime,
+    clinical_system
 FROM {{ ref('conformed_patient_person') }}

--- a/models/olids/stable/stable_person.sql
+++ b/models/olids/stable/stable_person.sql
@@ -39,6 +39,7 @@ SELECT
     patient_flagged_sensitive,
     error_success_code,
     lds_is_deleted,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_person') }}

--- a/models/olids/stable/stable_procedure_request.sql
+++ b/models/olids/stable/stable_procedure_request.sql
@@ -43,6 +43,7 @@ SELECT
     status_display,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_procedure_request') }}

--- a/models/olids/stable/stable_referral_request.sql
+++ b/models/olids/stable/stable_referral_request.sql
@@ -58,6 +58,7 @@ SELECT
     value,
     lds_is_deleted,
     publisher_organisation_code,
+    clinical_system,
     source_extraction_date,
     lds_transform_datetime
 FROM {{ ref('conformed_referral_request') }}


### PR DESCRIPTION
Refs #272, #273. Stacked on #271 (which stacks on #270) — merge in order; GitHub retargets down the chain.

## clinical_system

The feed carries system attribution only on PATIENT (`lds_source_dataset`). Because PATIENT is one record per practice registration per system, attribution cascades correctly by patient record: historical events keep the system that recorded them even across a future system migration. `conformed_patient` derives `clinical_system` (EMIS / SystmOne / raw passthrough) and the existing `conformed_patient` inner joins carry it to fourteen entities — zero new scans, complete by construction.

**Profiled: 0 nulls across all entities (2.7B+ rows), uniformly 'EMIS'.** Named `clinical_system` rather than `source_system` because eight models already publish `source_system` as the concept vocabulary namespace (e.g. `EMIS_CodeID_cs`); that existing column is untouched. Distinct from the future unified-layer `source_feed` (#266), which is pipeline provenance.

## FRESHNESS

Published watermark table, grain `(table_name, publisher_code)` with null publisher for table-level rows: processing watermarks (max `source_extraction_date` / `lds_transform_datetime` — is the pipeline moving) and content watermarks (max activity date per publisher excluding deleted rows and rows postdating their own extraction; table-level consensus = median of publisher maxima, with reporting/lagging counts — is the content current). Lag is data-to-data; no CURRENT_DATE. Computed from the stable tables themselves, so a gate-blocked build correctly leaves watermarks at previous values rather than advertising unpublished data. Verified live in `DATA_LAKE.OLIDS_EXPERIMENTAL.FRESHNESS` (283 practices reporting; DIAGNOSTIC_ORDER's known lag visible).

## Deploy hook

`on-run-end` calls `DATA_LAKE.CONTROL.DEPLOY_DATA_LAKE_VIEWS_FOR_SINGLE_SOURCE_MAPPING` with `FORCE_DEPLOY` (all-named arguments — Snowflake forbids mixing named and positional) whenever a run/build built at least one stable model. The proc uses `CREATE OR REPLACE VIEW` (atomic per view; no drop-then-create window) and drops only orphaned views. Schema changes and comment refreshes now propagate automatically — the stale-comment problem and the frozen-view breakage class (ORGANISATION, 2026-07-15) are both closed. Verified live: full redeploy in 32s, comments carrying the current run timestamp.

Known accepted gap: a breaking stable schema change leaves data_lake views on the old shape until the end of the run — empty in practice under nightly scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clinical_system` information across conformed and stable clinical data outputs, identifying source systems such as EMIS and SystmOne.
  * Added freshness reporting with per-publisher watermarks, activity lags, consensus dates and summary metrics.
  * Expanded terminology enrichment to retain unmapped source concepts and support additional local mappings.
* **Automation**
  * Data lake views are now redeployed automatically after successful model runs when relevant stable models are built.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->