### PR TITLE
fix(olids): build patient_person and person from the patient spine

### DIFF
--- a/models/olids/conformed/conformed_patient.sql
+++ b/models/olids/conformed/conformed_patient.sql
@@ -14,6 +14,7 @@ SELECT
     src.id AS source_id,
     src.lds_source_record_id,
     person_idx.person_id,
+    src.person_id AS person_uuid,
     src.publisher_organisation_id,
     src.provider_organisation_id,
     src.author_organisation_id,

--- a/models/olids/conformed/conformed_patient_person.sql
+++ b/models/olids/conformed/conformed_patient_person.sql
@@ -6,25 +6,53 @@
 
 /*
 Conformed patient-person bridge.
-Keeps only links for the filtered patient spine.
+
+Built from the patient spine, not the source PATIENT_PERSON feed: the feed is
+missing ~950k patient links that PATIENT.person_id carries (where both exist
+they always agree). Every conformed patient with a person UUID gets a bridge
+row; the source feed row supplies bridge metadata when present.
+
+Derived rows (no source feed row) reuse the patient source UUID as id and have
+NULL lds_source_record_id.
 */
 
+WITH bridge AS (
+    SELECT
+        id,
+        lds_source_record_id,
+        patient_id,
+        person_id,
+        lds_business_id_person,
+        lds_source_record_id_person,
+        gp_practice_code,
+        lds_is_deleted,
+        lds_transform_datetime
+    FROM {{ ref('landing_patient_person') }}
+    -- the feed can ship duplicate rows per patient; keep the latest
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY patient_id
+        ORDER BY lds_transform_datetime DESC NULLS LAST, id
+    ) = 1
+)
+
 SELECT
-    src.id,
-    src.lds_source_record_id,
-    patient_idx.patient_id,
-    person_idx.person_id,
-    src.person_id AS person_uuid,
-    src.lds_business_id_person,
-    src.lds_source_record_id_person,
-    src.gp_practice_code,
-    src.lds_is_deleted,
-    src.lds_transform_datetime,
+    COALESCE(bridge.id, patients.source_id) AS id,
+    bridge.lds_source_record_id,
+    patients.id AS patient_id,
+    COALESCE(patients.person_id, bridge_person_idx.person_id) AS person_id,
+    COALESCE(patients.person_uuid, bridge.person_id) AS person_uuid,
+    bridge.lds_business_id_person,
+    bridge.lds_source_record_id_person,
+    COALESCE(bridge.gp_practice_code, patients.publisher_organisation_code)
+        AS gp_practice_code,
+    COALESCE(bridge.lds_is_deleted, patients.lds_is_deleted) AS lds_is_deleted,
+    COALESCE(bridge.lds_transform_datetime, patients.lds_transform_datetime)
+        AS lds_transform_datetime,
     patients.clinical_system
-FROM {{ ref('landing_patient_person') }} AS src
-INNER JOIN {{ ref('conformed_patient') }} AS patients
-    ON src.patient_id = patients.source_id
-LEFT JOIN {{ ref('patient_id_index') }} AS patient_idx
-    ON src.patient_id = patient_idx.source_patient_id
-LEFT JOIN {{ ref('person_id_index') }} AS person_idx
-    ON src.person_id = person_idx.source_person_id
+FROM {{ ref('conformed_patient') }} AS patients
+LEFT JOIN bridge
+    ON patients.source_id = bridge.patient_id
+-- resolves feed-only person UUIDs for patients without their own person_id
+LEFT JOIN {{ ref('person_id_index') }} AS bridge_person_idx
+    ON bridge.person_id = bridge_person_idx.source_person_id
+WHERE COALESCE(patients.person_uuid, bridge.person_id) IS NOT NULL

--- a/models/olids/conformed/conformed_patient_person.sql
+++ b/models/olids/conformed/conformed_patient_person.sql
@@ -31,7 +31,7 @@ WITH bridge AS (
     -- the feed can ship duplicate rows per patient; keep the latest
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY patient_id
-        ORDER BY lds_transform_datetime DESC NULLS LAST, id
+        ORDER BY lds_transform_datetime DESC NULLS LAST, id ASC
     ) = 1
 )
 

--- a/models/olids/conformed/conformed_person.sql
+++ b/models/olids/conformed/conformed_person.sql
@@ -6,10 +6,22 @@
 
 /*
 Conformed PERSON view.
-Keeps people linked to the filtered patient spine and passes pseudonymised fields through.
+
+Driven from the patient-person bridge, not the source PERSON feed: the feed is
+missing ~830k persons that appear on PATIENT rows. Every bridged person gets a
+row; the feed record supplies pseudonymised attributes when present, otherwise
+they are NULL (gender and clinical_system fall back to the patient record).
 */
 
-WITH gender_fallback AS (
+WITH person_spine AS (
+    SELECT DISTINCT
+        person_id,
+        person_uuid
+    FROM {{ ref('conformed_patient_person') }}
+    WHERE person_id IS NOT NULL AND person_uuid IS NOT NULL
+),
+
+gender_fallback AS (
     SELECT
         pp.person_uuid,
         c.display AS gender,
@@ -26,8 +38,8 @@ WITH gender_fallback AS (
 )
 
 SELECT
-    person_idx.person_id AS id,
-    src.id AS person_uuid,
+    spine.person_id AS id,
+    spine.person_uuid,
     src.lds_source_record_id,
     src.req_nhs_number,
     src.matched_nhs_no,
@@ -56,25 +68,20 @@ SELECT
     src.mps_id,
     src.patient_flagged_sensitive,
     src.error_success_code,
-    src.lds_is_deleted,
+    COALESCE(src.lds_is_deleted, FALSE) AS lds_is_deleted,
     -- from the patient record backing this person row
     gf.clinical_system,
     src.source_extraction_date,
     src.lds_transform_datetime,
     COALESCE(src.gender, gf.gender) AS gender
-FROM {{ ref('landing_person') }} AS src
+FROM person_spine AS spine
+LEFT JOIN {{ ref('landing_person') }} AS src
+    ON spine.person_uuid = src.id
 LEFT JOIN gender_fallback AS gf
-    ON src.id = gf.person_uuid
-LEFT JOIN {{ ref('person_id_index') }} AS person_idx
-    ON src.id = person_idx.source_person_id
-WHERE EXISTS (
-    SELECT 1
-    FROM {{ ref('conformed_patient_person') }} AS pp
-    WHERE pp.person_uuid = src.id
-)
+    ON spine.person_uuid = gf.person_uuid
 -- identity resolution can map several source person records to one person_id;
 -- the person table carries one canonical row per person (latest record wins)
 QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY person_idx.person_id
-    ORDER BY src.lds_transform_datetime DESC NULLS LAST, src.id
+    PARTITION BY spine.person_id
+    ORDER BY src.lds_transform_datetime DESC NULLS LAST, spine.person_uuid
 ) = 1

--- a/models/olids/conformed/conformed_person.sql
+++ b/models/olids/conformed/conformed_person.sql
@@ -83,5 +83,5 @@ LEFT JOIN gender_fallback AS gf
 -- the person table carries one canonical row per person (latest record wins)
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY spine.person_id
-    ORDER BY src.lds_transform_datetime DESC NULLS LAST, spine.person_uuid
+    ORDER BY src.lds_transform_datetime DESC NULLS LAST, spine.person_uuid ASC
 ) = 1

--- a/models/olids/conformed/schema.yml
+++ b/models/olids/conformed/schema.yml
@@ -307,6 +307,8 @@ models:
                 severity: error
       - name: id
       - name: lds_source_record_id
+      - name: person_uuid
+        description: Source person UUID from PATIENT.person_id
       - name: gender_source_concept_id
       - name: registered_practice_organisation_id
       - name: clinical_system
@@ -351,19 +353,26 @@ models:
       - name: contact_type_source_concept_id
       - name: clinical_system
   - name: conformed_patient_person
-    description: 'Generated Patient Person conformed view.
+    description: 'Patient-person bridge built from the patient spine.
 
 
-      Applied filters:
+      Construction: one row per conformed patient with a person UUID, taken from
+      PATIENT.person_id. The source PATIENT_PERSON feed only supplies bridge
+      metadata where a feed row exists - it is missing ~950k patient links that
+      PATIENT.person_id carries, so it is no longer the driving table.
 
-      - Patient filtering: Inherits filtering from underlying patient relationships
 
-      - Practice filtering: Inherits WNL practice restriction through patient associations
+      Derived rows (no feed row) reuse the patient source UUID as id and have
+      NULL lds_source_record_id.
 
 
-      Filtering method: Filtered through relationships to conformed_patient'
+      Filtering: inherits WNL practice restriction and sensitive-patient
+      exclusions from conformed_patient.'
     columns:
       - name: patient_id
+        tests:
+          - unique
+          - not_null
       - name: person_id
       - name: id
       - name: clinical_system
@@ -377,20 +386,22 @@ models:
     columns:
       - name: patient_address_id
   - name: conformed_person
-    description: 'Filtered Person conformed view sourced from the pseudonymised PERSON feed.
+    description: 'Person view driven from the patient-person bridge.
 
 
-      Applied filters:
-
-      - Patient filtering: Restricted to people linked to WNL patients via PATIENT_PERSON
-
-
-      Filtering method: WHERE EXISTS against conformed_patient_person on person_uuid.
+      Construction: one row per bridged person. The source PERSON feed only
+      supplies pseudonymised attributes where a feed row exists - it is missing
+      ~830k persons that appear on PATIENT rows, so it is no longer the driving
+      table. Persons without a feed row carry NULL feed attributes; gender and
+      clinical_system fall back to the patient record.
 
 
       Identifiers: id is the indexed person id; person_uuid holds the source UUID.'
     columns:
       - name: id
+        tests:
+          - unique
+          - not_null
       - name: clinical_system
   - name: conformed_practitioner
     description: 'Filtered Practitioner conformed view.


### PR DESCRIPTION
Closes #275

## What

Rebuilds the olids-tree bridge and person tables from the patient spine instead of their source feeds (synapse tree unchanged):

- **`conformed_patient_person`** — driven from `conformed_patient`: one row per patient with a person UUID (from `PATIENT.person_id`). The source `PATIENT_PERSON` feed row supplies bridge metadata where it exists; derived rows reuse the patient source UUID as `id` and have NULL `lds_source_record_id`. Feed-only person UUIDs (patients without `person_id`) still resolve via `person_id_index`.
- **`conformed_person`** — driven from the bridge: one row per bridged person. The `PERSON` feed record supplies pseudonymised attributes where present; otherwise NULL, with gender and `clinical_system` falling back to the patient record (existing fallback CTE).
- **`conformed_patient`** — adds `person_uuid` (`PATIENT.person_id` passthrough) to support the above.
- Schema docs updated; new tests: `patient_id` unique + not_null on the bridge, `id` unique + not_null on person.

## Why

The source feeds are incomplete relative to `PATIENT.person_id` (0 mismatches where both exist — see #275): 953,134 patient links and 831,751 persons missing. Published tables re-inherited this, so consumers joining through `PATIENT_PERSON` silently drop ~860k persons — e.g. the dbt-analytics EMIS registration comparison fails 39 NCL practices in DEV vs 4 in PROD.

## Verification

Dry-run of the new logic against `OLIDS_ENGINEERING` (current landing/conformed/index tables):

| | Old | New |
|---|---:|---:|
| PATIENT_PERSON rows | 3,819,384 | 4,779,866 (+960,482 derived) |
| PATIENT_PERSON distinct persons | 3,138,554 | 3,999,770 |
| PERSON rows | 3,138,554 | 3,999,770 |

New bridge: `patient_id` unique, `id` unique (no bridge/patient UUID collisions), `person_id` never null. New person: `id` unique; 861,216 rows carry patient-fallback gender/clinical_system with NULL feed attributes.

sqlfluff violations in the changed files match the pre-existing patterns on main (AM03/ST06).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added person UUID information to conformed patient records.
  * Improved patient–person linking, including support for records without matching feed entries.
  * Enhanced conformed person records with fallback patient details where available.

* **Data Quality**
  * Added uniqueness and non-null validation for patient–person and conformed person identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->