### PR TITLE
chore(olids): publish stable to DATA_LAKE.OLIDS, synapse to OLIDS_SYNAPSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Foundational data layers for OLIDS (One London Integrated Data Set).
 
 | Tree | Feed | Coverage | Refresh | Publishes to |
 |---|---|---|---|---|
-| `models/olids` | `Data_Store_OLIDS_WNL` (experimental) | ~15 practices | Nightly | `OLIDS_ENGINEERING` database (`LANDING`/`CONFORMED`/`STABLE`) |
-| `models/synapse` | `Data_Store_OLIDS` (legacy Synapse) | Full NCL | Upstream refreshes fortnightly | `OLIDS_ENGINEERING` database (`SYNAPSE_BASE`/`SYNAPSE_STABLE`); `DATA_LAB_OLIDS_NCL.OLIDS` serves data_lake until the swap |
+| `models/olids` | `Data_Store_OLIDS_WNL` | NCL practices (production) | Nightly | `OLIDS_ENGINEERING` (`LANDING`/`CONFORMED`/`STABLE`) → `DATA_LAKE.OLIDS` |
+| `models/synapse` | `Data_Store_OLIDS` (legacy Synapse) | Full NCL, frozen since 16 July 2026 | None (upstream stopped) | `OLIDS_ENGINEERING` (`SYNAPSE_BASE`/`SYNAPSE_STABLE`) → `DATA_LAKE.OLIDS_SYNAPSE` |
 
 Run selectors:
 

--- a/macros/deploy_data_lake_views.sql
+++ b/macros/deploy_data_lake_views.sql
@@ -9,8 +9,8 @@
         {% endfor %}
         {% if stable_built | length > 0 %}
             {# Snowflake forbids mixing positional and named arguments: all named #}
-            {% do run_query("CALL DATA_LAKE.CONTROL.DEPLOY_DATA_LAKE_VIEWS_FOR_SINGLE_SOURCE_MAPPING(SOURCE_DATABASE => 'OLIDS_ENGINEERING', SOURCE_SCHEMA => 'STABLE', DESTINATION_SCHEMA => 'OLIDS_EXPERIMENTAL', FORCE_DEPLOY => TRUE)") %}
-            {% do log('data_lake OLIDS_EXPERIMENTAL views redeployed (' ~ stable_built | length ~ ' stable models built)', info=True) %}
+            {% do run_query("CALL DATA_LAKE.CONTROL.DEPLOY_DATA_LAKE_VIEWS_FOR_SINGLE_SOURCE_MAPPING(SOURCE_DATABASE => 'OLIDS_ENGINEERING', SOURCE_SCHEMA => 'STABLE', DESTINATION_SCHEMA => 'OLIDS', FORCE_DEPLOY => TRUE)") %}
+            {% do log('data_lake OLIDS views redeployed (' ~ stable_built | length ~ ' stable models built)', info=True) %}
         {% endif %}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
The new OLIDS feed is now the agreed production feed, and the legacy Synapse
feed has had no new data since 16 July (raised with OneLondon).

The run-end hook now deploys `OLIDS_ENGINEERING.STABLE` to `DATA_LAKE.OLIDS`
(was `OLIDS_EXPERIMENTAL`). The synapse tree moves to `DATA_LAKE.OLIDS_SYNAPSE`.

Landed together with the `DATA_LAKE.CONTROL.SOURCE_MAPPING` row updates
(Snowflake-Deployment), which repoint both destinations. The deploy procedure
takes its arguments directly, so this macro change must merge in the same
window as the mapping swap or the nightly run recreates `OLIDS_EXPERIMENTAL`.

README pipeline table updated to match.

Refs #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pipeline documentation to clarify the production OLIDS feed, legacy Synapse feed status, refresh schedules, coverage, and destination schemas.

* **Bug Fixes**
  * Data lake view deployments now target the correct production OLIDS destination instead of the experimental schema.
  * Deployment messages now accurately identify the destination being updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->